### PR TITLE
chore: add hashgraph scanner readiness

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,6 +2,15 @@
   "name": "superloopy",
   "version": "0.2.0",
   "description": "Lightweight loop harness with strict evidence gates.",
+  "homepage": "https://github.com/beefiker/superloopy#readme",
+  "repository": "https://github.com/beefiker/superloopy",
+  "keywords": [
+    "codex",
+    "codex-plugin",
+    "ai-agents",
+    "evidence-gates",
+    "proof-of-done"
+  ],
   "author": {
     "name": "beefiker"
   },
@@ -17,6 +26,7 @@
   ],
   "interface": {
     "displayName": "Superloopy",
+    "developerName": "beefiker",
     "shortDescription": "Strict evidence loop harness without heavyweight ceremony",
     "longDescription": "Superloopy provides repo-local loop state, explicit success criteria, append-only evidence ledgers, and Codex hook guardrails while keeping workflow overhead low.",
     "category": "Developer Tools",

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,29 @@
+name: HOL Plugin Scanner
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: HOL Plugin Scanner
+        uses: hashgraph-online/ai-plugin-scanner-action@7f7a17d8635a64c1d8890d3f5a21c7db1b9cc788 # v1
+        with:
+          plugin_dir: "."
+          mode: scan
+          min_score: 80
+          fail_on_severity: high
+          format: sarif
+          upload_sarif: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are accepted for the latest version on the `main` branch.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue with exploit details or sensitive information.
+
+Use GitHub's private vulnerability reporting for this repository if it is available. If private reporting is unavailable, open a minimal public issue asking for a private contact path, without including exploit details, secrets, or proof-of-concept payloads.
+
+A good report includes:
+
+- Affected version or commit SHA.
+- The vulnerable component or workflow.
+- Reproduction steps that avoid exposing real secrets or third-party systems.
+- Expected impact and any known mitigations.
+
+I will acknowledge valid reports as soon as practical, investigate, and publish a fix or mitigation note when appropriate.
+
+## Scope
+
+In scope:
+
+- The Superloopy CLI and bundled plugin files.
+- Repository-local evidence/state handling under `.superloopy/`.
+- Codex hook configuration shipped by this repository.
+
+Out of scope:
+
+- Social engineering.
+- Denial-of-service reports that rely only on excessive local resource consumption.
+- Vulnerabilities in third-party tools unless Superloopy's integration materially changes their risk.
+
+## No Bug Bounty
+
+This project does not currently run a paid bug bounty program.

--- a/docs/superloopy-file-audit.md
+++ b/docs/superloopy-file-audit.md
@@ -20,6 +20,7 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 | `.codex-plugin/plugin.json` | Local plugin metadata, hook registration, skill entry, and default Superloopy prompt. | Uses Codex plugin shape only; no external assets. |
 | `.gitignore` | Keeps runtime state, logs, coverage, and dependencies out of source control. | Superloopy runtime ignore set only. |
 | `LICENSE` | MIT license for this repo. | Standard license text. |
+| `SECURITY.md` | Vulnerability disclosure policy required for plugin catalog submissions. | Process documentation only; avoids publishing exploit details or secrets. |
 | `README.md` | English public product overview, language switcher, marketplace install flow, bootstrap behavior, command flow, state model, hooks, gates, and doctor checks. | Uses Superloopy-native product terms and current install commands. |
 | `README.ko.md` | Korean public product overview translated from the root README. | Documentation-only locale surface; mirrors Superloopy behavior without adding runtime logic. |
 | `README.zh-CN.md` | Simplified Chinese public product overview translated from the root README. | Documentation-only locale surface; mirrors Superloopy behavior without adding runtime logic. |
@@ -32,6 +33,7 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 | `.github/assets/robin.png` | README crew-card image for the robin auditor agent. | Documentation image only; no executable plugin logic. |
 | `.github/assets/nami.png` | README crew-card image for the nami navigator agent. | Documentation image only; no executable plugin logic. |
 | `.github/assets/transferloom-clone-reference.png` | README clone-demo screenshot showing the validated Transferloom.com Superloopy clone reference. | Documentation image only; generated from the local clone output and contains no executable plugin logic. |
+| `.github/workflows/hol-plugin-scanner.yml` | GitHub Actions workflow that runs the HOL plugin scanner for hashgraph awesome-list readiness. | Uses SHA-pinned Actions and scans the local plugin root only; no runtime plugin logic. |
 | `docs/superloopy-design-audit.md` | Doctor-verified decision matrix for naming, compatibility, and threshold records. | Records Superloopy decisions, not source-project lineage. |
 | `docs/superloopy-crew-lines.md` | Crew-line precedent, policy, and runtime contract for presentation-only handoff flavor. | Keeps lines Superloopy-original and non-authoritative beside mechanical evidence state. |
 | `docs/superloopy-file-audit.md` | File-by-file audit and reviewability note. | Proves every Git-visible file has a role and boundary. |
@@ -46,6 +48,7 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 | `hooks/subagent-stop-audit.json` | Registers robin verdict-receipt validation. | Verdict receipts use Superloopy evidence roots. |
 | `hooks/user-prompt-submit.json` | Registers steering and trigger-scoped context injection. | Structured `SUPERLOOPY_STEER` and explicit Superloopy prompt triggers only. |
 | `package.json` | Dependency-free Node package metadata, bin, and scripts including manifest version sync. | Keeps Superloopy small and dependency-free. |
+| `package-lock.json` | npm lockfile required by plugin catalog readiness checks. | Lockfile records the dependency-free package root only; no runtime dependencies are introduced. |
 | `scripts/sync-version.mjs` | Release helper that stamps `package.json` and `.codex-plugin/plugin.json` from one authoritative Superloopy version. | Superloopy release metadata only; no runtime dependency or publishing side effect. |
 | `skills/superloopy-clone/SKILL.md` | Skill instructions for authorized website cloning with browser extraction, component specs, implementation, and visual QA evidence. | Superloopy-governed workflow only; no template dependency or bundled external code. |
 | `skills/superloopy-clone/agents/openai.yaml` | Minimal agent metadata for discovering the Superloopy clone skill. | Superloopy-native skill metadata only. |
@@ -123,6 +126,16 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 | `test/pre-tool-use.test.js` | Focused unit tests for native goal-tool lifecycle guards. | Prevents premature native completion while Superloopy state is incomplete. |
 | `test/report.test.js` | Focused report artifact tests. | Tests report portability and guide output. |
 | `test/sync-version.test.js` | Release-helper tests for stamping package and plugin manifests from one version. | Tests Superloopy release metadata sync only. |
+| `web/README.md` | Static landing-page notes for the Superloopy web preview. | Documentation for the static site only; no plugin runtime behavior. |
+| `web/_headers` | Static-hosting security/cache headers for the Superloopy web preview. | Web deployment configuration only; does not affect the plugin package. |
+| `web/assets/franky.png` | Static landing-page agent illustration for franky. | Web presentation asset only; no executable plugin logic. |
+| `web/assets/jinbe.png` | Static landing-page agent illustration for jinbe. | Web presentation asset only; no executable plugin logic. |
+| `web/assets/luffy.svg` | Static landing-page logo/illustration asset. | Web presentation asset only; no executable plugin logic. |
+| `web/assets/nami.png` | Static landing-page agent illustration for nami. | Web presentation asset only; no executable plugin logic. |
+| `web/assets/robin.png` | Static landing-page agent illustration for robin. | Web presentation asset only; no executable plugin logic. |
+| `web/assets/usopp.png` | Static landing-page agent illustration for usopp. | Web presentation asset only; no executable plugin logic. |
+| `web/assets/zoro.png` | Static landing-page agent illustration for zoro. | Web presentation asset only; no executable plugin logic. |
+| `web/index.html` | Static marketing landing page for Superloopy. | Web preview only; kept separate from CLI/plugin runtime. |
 
 ## Weight Notes
 

--- a/docs/superloopy-loop-golden-set.md
+++ b/docs/superloopy-loop-golden-set.md
@@ -62,6 +62,7 @@ Total: 100 points.
 | `.codex-plugin/plugin.json` | `test/plugin.test.js`, doctor plugin manifest check. | Must expose `./skills/` and the packaged Superloopy hook files, including opt-in Stop. |
 | `.gitignore` | Doctor runtime-boundary ignored samples and installed-cache docs coverage. | `.superloopy/`, logs, coverage, dependencies, OS noise, and Codex marketplace metadata must stay out of source control. |
 | `LICENSE` | Audit coverage and reviewability check. | Must remain a source file with no runtime implementation content. |
+| `SECURITY.md` | Hashgraph catalog readiness. | Must document vulnerability reporting without publishing exploit details or secrets. |
 | `README.md` | `test/docs.test.js` public-doc assertions. | Must describe actual Superloopy install, bootstrap, commands, evidence rules, hooks, gates, doctor checks, and locale links. |
 | `README.ko.md` | `test/docs.test.js`, audit coverage. | Must provide the Korean README locale and keep install commands aligned with the root README. |
 | `README.zh-CN.md` | `test/docs.test.js`, audit coverage. | Must provide the Simplified Chinese README locale and keep install commands aligned with the root README. |
@@ -74,6 +75,7 @@ Total: 100 points.
 | `.github/assets/robin.png` | Audit coverage. | Must remain a README documentation image, not runtime plugin logic. |
 | `.github/assets/nami.png` | Audit coverage. | Must remain a README documentation image, not runtime plugin logic. |
 | `.github/assets/transferloom-clone-reference.png` | Audit coverage and README clone-demo reference. | Must remain a documentation screenshot for the validated Transferloom.com clone, not runtime plugin logic. |
+| `.github/workflows/hol-plugin-scanner.yml` | Hashgraph catalog readiness and GitHub Actions. | Must run the HOL scanner against the plugin root with SHA-pinned actions and no runtime side effects. |
 | `docs/superloopy-design-audit.md` | `src/design-audit.js`, `test/doctor.test.js`. | Must keep required decision rows with reason, effect, and guard. |
 | `docs/superloopy-crew-lines.md` | `test/docs.test.js`, audit coverage. | Must record the precedent pattern, no-copied-quotes rule, terminal-only behavior, and presentation-only authority boundary. |
 | `docs/superloopy-file-audit.md` | `test/audit.test.js`, `src/file-audit.js`, doctor file-audit check. | Must list every Git-visible file with non-empty role and compatibility-boundary cells. |
@@ -88,6 +90,7 @@ Total: 100 points.
 | `hooks/subagent-stop-audit.json` | `test/plugin.test.js`, doctor hook check. | Must route robin verdict validation through the Superloopy CLI. |
 | `hooks/user-prompt-submit.json` | `test/plugin.test.js`, doctor hook check. | Must route prompt steering and trigger-scoped context injection through the Superloopy CLI. |
 | `package.json` | `npm test`, doctor dependency check. | Must stay dependency-free and expose `superloopy`, `test`, `check`, and `sync-version` scripts. |
+| `package-lock.json` | Hashgraph catalog readiness and npm audit surface. | Must lock only the dependency-free package root unless real dependencies are intentionally added. |
 | `scripts/sync-version.mjs` | `test/sync-version.test.js`. | Must stamp `package.json` and `.codex-plugin/plugin.json` from one authoritative version without publishing or adding dependencies. |
 | `skills/superloopy-clone/SKILL.md` | `test/plugin.test.js`, audit coverage. | Must describe authorized browser-assisted website cloning with specs, assets, build validation, visual QA, and Superloopy evidence receipts. |
 | `skills/superloopy-clone/agents/openai.yaml` | Audit coverage and reviewability check. | Must remain minimal Superloopy discovery metadata for website cloning. |
@@ -165,6 +168,16 @@ Total: 100 points.
 | `test/pre-tool-use.test.js` | `npm test`. | Must verify Superloopy blocks native complete status until aggregate completion is real. |
 | `test/report.test.js` | `npm test`. | Must verify report artifacts remain portable and guide-backed. |
 | `test/sync-version.test.js` | `npm test`. | Must prove Superloopy package and plugin manifest versions are stamped from one release version. |
+| `web/README.md` | Static landing-page documentation. | Must describe the static web preview without changing plugin runtime contracts. |
+| `web/_headers` | Static-hosting headers. | Must remain deployment configuration only. |
+| `web/assets/franky.png` | Static landing-page franky asset. | Must remain a web presentation image, not runtime plugin logic. |
+| `web/assets/jinbe.png` | Static landing-page jinbe asset. | Must remain a web presentation image, not runtime plugin logic. |
+| `web/assets/luffy.svg` | Static landing-page logo/illustration asset. | Must remain a web presentation image, not runtime plugin logic. |
+| `web/assets/nami.png` | Static landing-page nami asset. | Must remain a web presentation image, not runtime plugin logic. |
+| `web/assets/robin.png` | Static landing-page robin asset. | Must remain a web presentation image, not runtime plugin logic. |
+| `web/assets/usopp.png` | Static landing-page usopp asset. | Must remain a web presentation image, not runtime plugin logic. |
+| `web/assets/zoro.png` | Static landing-page zoro asset. | Must remain a web presentation image, not runtime plugin logic. |
+| `web/index.html` | Static marketing landing page. | Must stay separate from the CLI/plugin runtime and within reviewability limits. |
 
 ## Run History
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "superloopy",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "superloopy",
+      "version": "0.2.0",
+      "license": "MIT",
+      "bin": {
+        "superloopy": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` and `package-lock.json` for hashgraph plugin-catalog readiness.
- Add a SHA-pinned HOL Plugin Scanner GitHub Actions workflow.
- Fill recommended plugin manifest metadata required by the scanner publishability checks.
- Update Superloopy's strict file-audit/golden-set inventories for the new readiness files and current web assets.

## Validation
- `npm test` → 245/245 passing
- `node src/cli.js doctor --json` → overall ok
- `git diff --check`
- `plugin-scanner lint . --format text` → effective_score=93, policy_pass=True
- `plugin-scanner verify . --format text` → PASS
- `plugin-scanner scan . --format text` → Final Score: 93/100, critical:0, high:0, medium:0

## Notes
- The HOL scanner wheel hash matched the reviewed `plugin-scanner==2.0.930` SHA256 from `hashgraph-online/awesome-codex-plugins` CONTRIBUTING.md.
- Remaining scanner findings are non-blocking: one low Dependabot suggestion and informational metadata suggestions.
