### PR TITLE
chore: add plugin composer icon

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -42,6 +42,8 @@
       "Record Superloopy evidence for this change, using superloopy loop prove when command output is the proof."
     ],
     "brandColor": "#2563EB",
-    "screenshots": []
+    "screenshots": [],
+    "composerIcon": "./web/assets/luffy.svg",
+    "logo": "./web/assets/luffy.svg"
   }
 }


### PR DESCRIPTION
## Summary
- Add a local `composerIcon` asset path to the Codex plugin interface metadata.
- Reuse the existing lightweight SVG web asset so hashgraph list validation can resolve the required icon without adding new binary assets.

## Validation
- `npm test`
- `node src/cli.js doctor --json`
- `plugin-scanner lint . --format text`
- `plugin-scanner verify . --format text`
- `plugin-scanner scan . --format text` → Final Score: 93/100, critical:0, high:0, medium:0
- `git diff --check`
