### PR TITLE
Fix Superloopy lockfile version sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superloopy",
-  "version": "0.2.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superloopy",
-      "version": "0.2.0",
+      "version": "0.5.1",
       "license": "MIT",
       "bin": {
         "superloopy": "src/cli.js"

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -48,6 +48,33 @@ async function stampJsonVersion(path, version) {
   return true;
 }
 
+async function stampPackageLockVersion(path, version) {
+  let parsed;
+  try {
+    parsed = await readJson(path);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return false;
+
+  let changed = false;
+  if (parsed.version !== version) {
+    parsed.version = version;
+    changed = true;
+  }
+
+  const rootPackage = parsed.packages?.[""];
+  if (typeof rootPackage === "object" && rootPackage !== null && rootPackage.version !== version) {
+    rootPackage.version = version;
+    changed = true;
+  }
+
+  if (!changed) return false;
+  await writeJson(path, parsed);
+  return true;
+}
+
 export function manifestTargets(repoRoot) {
   return [
     join(repoRoot, "package.json"),
@@ -63,6 +90,8 @@ export async function syncVersion(options = {}) {
   for (const target of targets) {
     if (await stampJsonVersion(target, version)) changed.push(target);
   }
+  const packageLock = join(repoRoot, "package-lock.json");
+  if (await stampPackageLockVersion(packageLock, version)) changed.push(packageLock);
   return { version, targets, changed };
 }
 

--- a/test/sync-version.test.js
+++ b/test/sync-version.test.js
@@ -10,13 +10,20 @@ test("syncVersion stamps package and plugin manifests from the authoritative roo
   const repo = await mkdtemp(join(tmpdir(), "superloopy-sync-version-"));
   await mkdir(join(repo, ".codex-plugin"), { recursive: true });
   await writeFile(join(repo, "package.json"), `${JSON.stringify({ name: "superloopy", version: "0.2.0" }, null, 2)}\n`);
+  await writeFile(
+    join(repo, "package-lock.json"),
+    `${JSON.stringify({ name: "superloopy", version: "0.1.0", packages: { "": { name: "superloopy", version: "0.1.0" } } }, null, 2)}\n`
+  );
   await writeFile(join(repo, ".codex-plugin", "plugin.json"), `${JSON.stringify({ name: "superloopy", version: "0.1.0" }, null, 2)}\n`);
 
   const result = await syncVersion({ repoRoot: repo });
 
   assert.equal(result.version, "0.2.0");
-  assert.deepEqual(result.changed, [join(repo, ".codex-plugin", "plugin.json")]);
+  assert.deepEqual(result.changed, [join(repo, ".codex-plugin", "plugin.json"), join(repo, "package-lock.json")]);
   assert.equal(JSON.parse(await readFile(join(repo, "package.json"), "utf8")).version, "0.2.0");
+  const packageLock = JSON.parse(await readFile(join(repo, "package-lock.json"), "utf8"));
+  assert.equal(packageLock.version, "0.2.0");
+  assert.equal(packageLock.packages[""].version, "0.2.0");
   assert.equal(JSON.parse(await readFile(join(repo, ".codex-plugin", "plugin.json"), "utf8")).version, "0.2.0");
 });
 
@@ -24,11 +31,18 @@ test("syncVersion honors an explicit release version", async () => {
   const repo = await mkdtemp(join(tmpdir(), "superloopy-sync-version-explicit-"));
   await mkdir(join(repo, ".codex-plugin"), { recursive: true });
   await writeFile(join(repo, "package.json"), `${JSON.stringify({ name: "superloopy", version: "0.1.0" }, null, 2)}\n`);
+  await writeFile(
+    join(repo, "package-lock.json"),
+    `${JSON.stringify({ name: "superloopy", version: "0.1.0", packages: { "": { name: "superloopy", version: "0.1.0" } } }, null, 2)}\n`
+  );
   await writeFile(join(repo, ".codex-plugin", "plugin.json"), `${JSON.stringify({ name: "superloopy", version: "0.1.0" }, null, 2)}\n`);
 
   const result = await syncVersion({ repoRoot: repo, version: "0.3.0" });
 
   assert.equal(result.version, "0.3.0");
   assert.equal(JSON.parse(await readFile(join(repo, "package.json"), "utf8")).version, "0.3.0");
+  const packageLock = JSON.parse(await readFile(join(repo, "package-lock.json"), "utf8"));
+  assert.equal(packageLock.version, "0.3.0");
+  assert.equal(packageLock.packages[""].version, "0.3.0");
   assert.equal(JSON.parse(await readFile(join(repo, ".codex-plugin", "plugin.json"), "utf8")).version, "0.3.0");
 });


### PR DESCRIPTION
## Summary
- update package-lock.json from 0.2.0 to 0.5.1 so marketplace installs resolve the current plugin version
- teach scripts/sync-version.mjs to sync package-lock.json root versions as well
- add tests that catch package-lock.json drifting behind package.json/plugin.json

## Verification
- npm run sync-version
- npm test
