### PR TITLE
docs: make Update/Uninstall/Troubleshooting dual-host (all READMEs)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -109,6 +109,8 @@ Recarga los plugins (o reinicia Claude Code) y aprueba los hooks cuando te lo pi
 
 ## Actualización
 
+### Codex
+
 Si instalaste desde el Codex marketplace, actualiza el marketplace snapshot:
 
 ```
@@ -135,13 +137,29 @@ superloopy doctor
 
 Las instalaciones desde checkout no están gestionadas por `npx`. El self-update con `npx` queda reservado para un instalador futuro que escriba un snapshot `superloopy-install.json` en una raíz de instalación estable.
 
+### Claude Code
+
+Actualiza el marketplace, reinstala para resolver la versión nueva y luego recarga; no hace falta reiniciar:
+
+```
+/plugin marketplace update beefiker
+/plugin install superloopy@beefiker
+/reload-plugins
+```
+
+No hay un comando `/plugin update` aparte: reinstalar desde el marketplace actualizado resuelve la versión nueva, y `/reload-plugins` la aplica en la sesión actual (sin reiniciar Claude Code, y los hooks no necesitan volver a aprobarse). Verifica con `node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json`. Si cargaste un checkout con `--plugin-dir`, basta con `git pull --ff-only` y ejecutar `/reload-plugins`.
+
 ## Solución de problemas
 
 Si fallan los comandos de instalación o actualización del plugin, actualiza primero el Codex CLI. `codex plugin add` está disponible desde Codex CLI 0.131.0 en adelante; las versiones antiguas pueden tener problemas con los comandos actuales de plugin marketplace y los flujos de aprobación de hooks.
 
 Después de actualizar el CLI, reinicia Codex, vuelve a ejecutar el comando de instalación o actualización del marketplace, aprueba cualquier hook Modified y revisa con `superloopy doctor`.
 
+En Claude Code, si los comandos `/plugin` fallan o el plugin parece viejo, ejecuta `/reload-plugins` (o reinicia Claude Code) y verifica con `node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json`.
+
 ## Desinstalación
+
+### Codex
 
 Elimina el plugin instalado de Codex:
 
@@ -163,5 +181,14 @@ rm -f ~/.codex/agents/franky.toml ~/.codex/agents/zoro.toml ~/.codex/agents/usop
 ```
 
 Si instalaste con `CODEX_HOME`, `SUPERLOOPY_BIN_DIR` o `CODEX_LOCAL_BIN_DIR`, limpia esas rutas configuradas.
+
+### Claude Code
+
+```
+/plugin uninstall superloopy@beefiker
+/plugin marketplace remove beefiker
+```
+
+Luego ejecuta `/reload-plugins`. No hay nada más que limpiar: las instalaciones en Claude Code van completamente incluidas en el plugin (sin wrapper `superloopy`, sin escrituras en `~/.codex`). Eliminar el marketplace de su último scope restante también desinstala el plugin.
 
 <sub>Licencia MIT.</sub>

--- a/README.ja.md
+++ b/README.ja.md
@@ -109,6 +109,8 @@ Node.js 20 以上が必要です。同じ repo から:
 
 ## 更新
 
+### Codex
+
 Codex marketplace からインストールした場合は、marketplace snapshot を更新します。
 
 ```
@@ -135,13 +137,29 @@ superloopy doctor
 
 checkout インストールは `npx` 管理ではありません。`npx` self-update は、安定したインストール先に `superloopy-install.json` snapshot を書き込む将来の installer のために予約されています。
 
+### Claude Code
+
+marketplace を更新し、新しいバージョンを解決するために再インストールしてから再読み込みします。再起動は不要です。
+
+```
+/plugin marketplace update beefiker
+/plugin install superloopy@beefiker
+/reload-plugins
+```
+
+別途 `/plugin update` コマンドはありません。更新済み marketplace から再インストールすると新しいバージョンが解決され、`/reload-plugins` が現在のセッションにそれを適用します（Claude Code の再起動は不要で、hooks の再承認も必要ありません）。`node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json` で確認してください。`--plugin-dir` で checkout を読み込んでいる場合は、`git pull --ff-only` を実行して `/reload-plugins` するだけです。
+
 ## トラブルシューティング
 
 プラグインのインストールまたは更新コマンドが失敗する場合は、まず Codex CLI を更新してください。`codex plugin add` は Codex CLI 0.131.0 以降で使えます。古い Codex CLI では、現在の plugin marketplace コマンドや hook 承認フローがうまく動かないことがあります。
 
 CLI 更新後に Codex を再起動し、marketplace のインストールまたは更新コマンドを再実行してください。Modified hooks が表示されたら承認し、`superloopy doctor` で確認します。
 
+Claude Code で `/plugin` コマンドが失敗する、またはプラグインが古いままに見える場合は、`/reload-plugins`（または Claude Code の再起動）を実行し、`node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json` で確認してください。
+
 ## アンインストール
+
+### Codex
 
 Codex からインストール済みプラグインを削除します。
 
@@ -163,5 +181,14 @@ rm -f ~/.codex/agents/franky.toml ~/.codex/agents/zoro.toml ~/.codex/agents/usop
 ```
 
 `CODEX_HOME`、`SUPERLOOPY_BIN_DIR`、`CODEX_LOCAL_BIN_DIR` を使ってインストール先を変えた場合は、その設定先を削除してください。
+
+### Claude Code
+
+```
+/plugin uninstall superloopy@beefiker
+/plugin marketplace remove beefiker
+```
+
+その後 `/reload-plugins` を実行してください。他に片付けるものはありません。Claude Code インストールは完全にプラグインに同梱されています（`superloopy` wrapper も `~/.codex` への書き込みもありません）。最後に残っていたスコープから marketplace を削除すると、プラグインもアンインストールされます。
 
 <sub>MIT ライセンス。</sub>

--- a/README.ko.md
+++ b/README.ko.md
@@ -109,6 +109,8 @@ Node.js 20 이상이 필요합니다. 같은 repo에서:
 
 ## 업데이트
 
+### Codex
+
 Codex marketplace로 설치했다면 marketplace snapshot을 갱신합니다.
 
 ```
@@ -135,13 +137,29 @@ superloopy doctor
 
 checkout 설치는 `npx` 관리 대상이 아닙니다. `npx` self-update는 안정적인 설치 위치에 `superloopy-install.json` snapshot을 남기는 별도 installer가 생긴 뒤에만 켭니다.
 
+### Claude Code
+
+marketplace를 갱신하고, 새 버전을 받도록 다시 설치한 뒤 리로드하세요. 재시작은 필요 없습니다.
+
+```
+/plugin marketplace update beefiker
+/plugin install superloopy@beefiker
+/reload-plugins
+```
+
+별도의 `/plugin update` 명령은 없습니다. 갱신된 marketplace에서 다시 설치하면 새 버전이 잡히고, `/reload-plugins`가 현재 세션에 적용합니다(Claude Code 재시작이 필요 없고, hooks도 다시 승인할 필요가 없습니다). 확인은 `node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json`으로 합니다. `--plugin-dir`로 checkout을 로드했다면 `git pull --ff-only` 후 `/reload-plugins`만 하면 됩니다.
+
 ## 트러블슈팅
 
 플러그인 설치나 업데이트 명령이 실패하면 Codex CLI를 먼저 최신 버전으로 업데이트하세요. `codex plugin add`는 Codex CLI 0.131.0부터 사용할 수 있으므로, 구버전 Codex CLI에서는 현재 plugin marketplace 명령이나 hook 승인 흐름이 어려울 수 있습니다.
 
 CLI를 업데이트한 뒤 Codex를 재시작하고 marketplace 설치 또는 업데이트 명령을 다시 실행하세요. Modified hooks가 보이면 승인한 다음 `superloopy doctor`로 확인하세요.
 
+Claude Code에서는 `/plugin` 명령이 실패하거나 플러그인이 예전 상태처럼 보이면 `/reload-plugins`를 실행하거나(또는 Claude Code를 재시작하고) `node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json`으로 확인하세요.
+
 ## 제거
+
+### Codex
 
 Codex에서 설치된 플러그인을 제거합니다.
 
@@ -163,5 +181,14 @@ rm -f ~/.codex/agents/franky.toml ~/.codex/agents/zoro.toml ~/.codex/agents/usop
 ```
 
 `CODEX_HOME`, `SUPERLOOPY_BIN_DIR`, `CODEX_LOCAL_BIN_DIR`로 설치 위치를 바꿨다면 그 경로를 정리하세요.
+
+### Claude Code
+
+```
+/plugin uninstall superloopy@beefiker
+/plugin marketplace remove beefiker
+```
+
+그런 다음 `/reload-plugins`를 실행하세요. 그 외에 정리할 것은 없습니다. Claude Code 설치는 완전히 플러그인에 번들되어 있습니다(`superloopy` wrapper도 없고 `~/.codex`에 쓰는 것도 없습니다). 마지막으로 남은 스코프에서 marketplace를 제거하면 플러그인도 함께 제거됩니다.
 
 <sub>MIT 라이선스.</sub>

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Reload plugins (or restart Claude Code) and approve the hooks when prompted. On 
 
 ## Update
 
+### Codex
+
 If you installed from the Codex marketplace, refresh the marketplace snapshot:
 
 ```
@@ -135,13 +137,29 @@ superloopy doctor
 
 Checkout installs are not `npx`-managed. `npx` self-update is reserved for a future installer that writes a `superloopy-install.json` snapshot into a stable install root.
 
+### Claude Code
+
+Refresh the marketplace, reinstall to resolve the new version, then reload — no restart needed:
+
+```
+/plugin marketplace update beefiker
+/plugin install superloopy@beefiker
+/reload-plugins
+```
+
+There is no separate `/plugin update` command: reinstalling from the refreshed marketplace resolves the new version, and `/reload-plugins` applies it in the current session (no Claude Code restart, and hooks do not need re-approval). Verify with `node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json`. If you loaded a checkout with `--plugin-dir`, just `git pull --ff-only` and run `/reload-plugins`.
+
 ## Troubleshooting
 
 If plugin install or upgrade commands fail, update the Codex CLI first. `codex plugin add` is available in Codex CLI 0.131.0 and newer; older builds can have trouble with current plugin marketplace commands and hook approval flows.
 
 After updating the CLI, restart Codex, run the marketplace install or upgrade command again, approve any Modified hooks, then check with `superloopy doctor`.
 
+On Claude Code, if `/plugin` commands fail or the plugin looks stale, run `/reload-plugins` (or restart Claude Code) and verify with `node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json`.
+
 ## Uninstall
+
+### Codex
 
 Remove the installed plugin from Codex:
 
@@ -163,5 +181,14 @@ rm -f ~/.codex/agents/franky.toml ~/.codex/agents/zoro.toml ~/.codex/agents/usop
 ```
 
 If you installed with `CODEX_HOME`, `SUPERLOOPY_BIN_DIR`, or `CODEX_LOCAL_BIN_DIR`, clean up those configured paths instead.
+
+### Claude Code
+
+```
+/plugin uninstall superloopy@beefiker
+/plugin marketplace remove beefiker
+```
+
+Then run `/reload-plugins`. Nothing else to clean up — Claude Code installs are fully plugin-bundled (no `superloopy` wrapper, no `~/.codex` writes). Removing the marketplace from its last remaining scope also uninstalls the plugin.
 
 <sub>MIT licensed.</sub>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,6 +109,8 @@ codex plugin add superloopy@beefiker
 
 ## 更新
 
+### Codex
+
 如果通过 Codex marketplace 安装，刷新 marketplace snapshot：
 
 ```
@@ -135,13 +137,29 @@ superloopy doctor
 
 checkout 安装不是 `npx` 管理的。`npx` self-update 只会在未来有稳定 installer、并在安装根目录写入 `superloopy-install.json` snapshot 之后启用。
 
+### Claude Code
+
+刷新 marketplace，重新安装以解析新版本，然后重新加载——无需重启：
+
+```
+/plugin marketplace update beefiker
+/plugin install superloopy@beefiker
+/reload-plugins
+```
+
+没有单独的 `/plugin update` 命令：从已刷新的 marketplace 重新安装即可解析出新版本，`/reload-plugins` 会在当前会话中应用它（无需重启 Claude Code，hooks 也不需要重新批准）。用 `node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json` 验证。如果你用 `--plugin-dir` 加载了一个 checkout，只需 `git pull --ff-only` 再运行 `/reload-plugins`。
+
 ## 故障排除
 
 如果插件安装或更新命令失败，请先更新 Codex CLI。`codex plugin add` 从 Codex CLI 0.131.0 开始可用；旧版本可能无法顺利处理当前的 plugin marketplace 命令和 hook 审批流程。
 
 更新 CLI 后重启 Codex，再次运行 marketplace 安装或更新命令，批准所有 Modified hooks，然后用 `superloopy doctor` 检查。
 
+在 Claude Code 上，如果 `/plugin` 命令失败或插件看起来像旧版本，请运行 `/reload-plugins`（或重启 Claude Code），再用 `node "${CLAUDE_PLUGIN_ROOT}/src/cli.js" doctor --json` 验证。
+
 ## 卸载
+
+### Codex
 
 从 Codex 删除已安装插件：
 
@@ -163,5 +181,14 @@ rm -f ~/.codex/agents/franky.toml ~/.codex/agents/zoro.toml ~/.codex/agents/usop
 ```
 
 如果安装时使用了 `CODEX_HOME`、`SUPERLOOPY_BIN_DIR` 或 `CODEX_LOCAL_BIN_DIR`，请清理对应路径。
+
+### Claude Code
+
+```
+/plugin uninstall superloopy@beefiker
+/plugin marketplace remove beefiker
+```
+
+然后运行 `/reload-plugins`。没有其他需要清理的东西——Claude Code 安装完全随插件打包（没有 `superloopy` wrapper，也不写入 `~/.codex`）。从最后一个作用域移除该 marketplace 也会一并卸载插件。
 
 <sub>MIT 许可证。</sub>


### PR DESCRIPTION
Follow-up to #6. The Update and Uninstall sections were still Codex-only after #6 merged; this splits both into `### Codex` + `### Claude Code` across all five READMEs (en/ko/ja/zh-CN/es) and adds a Claude Code note to Troubleshooting.

Claude Code paths (verified against the Claude Code plugin docs):
- **Update:** `/plugin marketplace update beefiker` → `/plugin install superloopy@beefiker` → `/reload-plugins` (no separate `/plugin update`, no restart, no hook re-approval; `--plugin-dir` checkout → `git pull --ff-only` + `/reload-plugins`).
- **Uninstall:** `/plugin uninstall superloopy@beefiker` + `/plugin marketplace remove beefiker` → `/reload-plugins` (fully plugin-bundled, nothing else to clean up).

Codex subsections unchanged. Each README now has `### Codex` + `### Claude Code` across Install, Update, and Uninstall.

Test plan: `npm test` → 306/306.