### PR TITLE
doctor: advisory check for a stale/dangling bin wrapper after upgrade

### DIFF
--- a/docs/superloopy-file-audit.md
+++ b/docs/superloopy-file-audit.md
@@ -200,7 +200,7 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 | `src/continuation.js` | Bounded, progress-gated Stop-hook engine that drives the loop toward evidence-backed completion and marks blocked on a cap or stall. | Superloopy-native continuation; never force-completes. |
 | `src/crew-lines.js` | Deterministic original localized one-line responses for known crew handoffs with terminal verdicts. | Output-only flavor; pending or unknown lanes stay silent and persisted handoff state is not decorated. |
 | `src/design-audit.js` | Verifies Superloopy design audit sections and decision rows. | Guards Superloopy-native decisions. |
-| `src/doctor.js` | Local health check orchestrator for package, hooks, Claude host wiring, docs, comparison scan, Codex + Claude model policy, and reviewability. | Enforces file audits, design audits, Claude host wiring, and advisory model defaults on both hosts. |
+| `src/doctor.js` | Local health check orchestrator for package, hooks, Claude host wiring, docs, comparison scan, Codex + Claude model policy, reviewability, and advisory bin wrapper currency. | Enforces file audits, design audits, Claude host wiring, and advisory model defaults on both hosts. |
 | `src/engineer.js` | Loop-engineer trigger that turns the `loopy` keyword (and Korean alias `루피`) into a guided drive of begin, prove, check, and finish, plus guidance-only frontend and Korean-writing steers. | Superloopy keyword activation and guide-backed context. |
 | `src/file-audit.js` | Row-level file inventory verifier for audit coverage, stale rows, incomplete rows, and native boundary policy. | Checks Superloopy audit structure. |
 | `src/finish.js` | One-command finalization that writes the default gate, checkpoints remaining goals, writes the report, and returns the complete guide. | Superloopy-specific lighter flow. |
@@ -226,6 +226,7 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 | `src/spawn-command.js` | Cross-platform process invocation helper for npm/npx command shims. | Minimal Superloopy utility used by update planning only. |
 | `src/subagent-attempts.js` | SubagentStop evidence-receipt attempt tracking and the post-cap ledger signal, factored out of hooks.js. | Superloopy-native; keeps hooks.js within the reviewability budget. |
 | `src/trace.js` | Builds compact evidence trail with summary counts, warnings, missing proof, suggested paths, and timeline. | Superloopy-only inspection surface. |
+| `src/wrapper-check.js` | Advisory doctor check that reads the installed `superloopy` bin wrapper and reports when it points at a stale or pruned versioned cache after an upgrade. | Superloopy-native; informational only (never fails health), no-throw, and dependency-injectable. |
 | `test/audit.test.js` | Prevents this audit from missing repository files or reviewability limits. | Tests Superloopy file inventory. |
 | `test/auto-update.test.js` | Auto-update contract tests for marketplace skip notices, checkout skip behavior, npx-local snapshot behavior, semver planning, install-flow detection, and Windows npx shims. | Tests Superloopy's adapted LazyCodex-style update flow without requiring an npm publish. |
 | `test/subagent-receipt.test.js` | SubagentStop attempt-cap robustness and exhaustion ledger-signal tests. | Tests Superloopy receipt gate behavior. |

--- a/docs/superloopy-loop-golden-set.md
+++ b/docs/superloopy-loop-golden-set.md
@@ -268,6 +268,7 @@ Total: 100 points.
 | `src/spawn-command.js` | `test/auto-update.test.js`. | Must route npm/npx through Windows `.cmd` shims and leave other commands unchanged. |
 | `src/subagent-attempts.js` | `npm test`, doctor reviewability. | Must count the 3-attempt cap (with a session/cwd fallback key) and record the exhaustion ledger signal. |
 | `src/trace.js` | Loop-gate and CLI evidence tests. | Must show artifact-backed proof, warnings, missing proof, suggested paths, ledger timeline, and evidence summary counts. |
+| `src/wrapper-check.js` | `test/doctor.test.js`. | Must read the installed bin wrapper and advise (never fail) when it points at a stale or pruned versioned cache after an upgrade; informational, no-throw, and dependency-injectable. |
 | `test/audit.test.js` | `npm test`. | Must fail if repo files are missing from audit or reviewability limits are exceeded. |
 | `test/auto-update.test.js` | `npm test`. | Must prove marketplace skip notices, checkout skip behavior, future npx-local snapshot behavior, semver planning, install-flow detection, and Windows npx shims. |
 | `test/subagent-receipt.test.js` | `npm test`. | Must prove the attempt cap counts without agent_id and records a ledger signal on exhaustion. |

--- a/src/agents.js
+++ b/src/agents.js
@@ -272,7 +272,10 @@ export function parseBinShimCliPath(content, platform = process.platform) {
     const match = /^node "([^"\n]+)" %\*/mu.exec(normalized);
     return match === null ? null : match[1];
   }
-  const match = /^exec node (?:'((?:[^'\\]|\\.)*)'|(\S+)) "\$@"/mu.exec(normalized);
+  // Reverse shellQuote: a single-quoted token whose interior apostrophes are encoded as the
+  // 4-char sequence '\'' — so the quoted branch must treat '\'' as content, not a close-quote,
+  // or a path like /home/o'connor falls through to the raw \S+ token and never resolves.
+  const match = /^exec node (?:'((?:[^']|'\\'')*)'|(\S+)) "\$@"/mu.exec(normalized);
   if (match === null) return null;
   return match[1] === undefined ? match[2] : match[1].replaceAll("'\\''", "'");
 }

--- a/src/agents.js
+++ b/src/agents.js
@@ -262,6 +262,21 @@ function binShimContent(cliPath, platform) {
   return `#!/usr/bin/env sh\n# ${BIN_SHIM_MARKER}\nexec node ${shellQuote(cliPath)} "$@"\n`;
 }
 
+// Extract the cli.js path a generated Superloopy shim executes, or null when the content is
+// not one of our shims. Recognizes both the marked form and the legacy structure, so doctor
+// can read where an installed wrapper actually points (e.g. a stale versioned cache path).
+export function parseBinShimCliPath(content, platform = process.platform) {
+  if (typeof content !== "string" || !isGeneratedSuperloopyBinShim(content, platform)) return null;
+  const normalized = content.replace(/\r\n/gu, "\n");
+  if (platform === "win32") {
+    const match = /^node "([^"\n]+)" %\*/mu.exec(normalized);
+    return match === null ? null : match[1];
+  }
+  const match = /^exec node (?:'((?:[^'\\]|\\.)*)'|(\S+)) "\$@"/mu.exec(normalized);
+  if (match === null) return null;
+  return match[1] === undefined ? match[2] : match[1].replaceAll("'\\''", "'");
+}
+
 function shellQuote(value) {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -8,6 +8,7 @@ import { checkComparisonSimilarity } from "./comparison-similarity.js";
 import { SUPERLOOPY_AGENT_NAMES } from "./agents.js";
 import { checkClaudeModelPolicy, checkModelPolicy } from "./model-policy.js";
 import { checkInterop } from "./interop.js";
+import { checkWrapper } from "./wrapper-check.js";
 
 const FILE_AUDIT_PATH = "docs/superloopy-file-audit.md";
 const GATE_NOTES_PATH = "docs/superloopy-gate-notes.md";
@@ -35,11 +36,7 @@ export async function runDoctor(cwd, options = {}) {
   const cli = checkCli(cwd);
   const dependencies = await checkDependencies(cwd);
   const runtimeBoundary = checkRuntimeBoundary(cwd);
-  const fileAudit = await checkFileAudit(cwd, {
-    auditPath: FILE_AUDIT_PATH,
-    policy: "superloopy-native-boundary",
-    listFiles: listGitVisibleFiles
-  });
+  const fileAudit = await checkFileAudit(cwd, { auditPath: FILE_AUDIT_PATH, policy: "superloopy-native-boundary", listFiles: listGitVisibleFiles });
   const gateNotes = await checkGateNotes(cwd);
   const designAudit = await checkDesignAudit(cwd, {
     auditPath: DESIGN_AUDIT_PATH
@@ -55,7 +52,7 @@ export async function runDoctor(cwd, options = {}) {
   const claudeHostWiring = await checkClaudeHostWiring(cwd);
   const modelPolicy = await checkModelPolicy(cwd);
   const claudeModelPolicy = await checkClaudeModelPolicy(cwd);
-  const checks = { pluginManifest, hooks, skills, cli, dependencies, runtimeBoundary, fileAudit, gateNotes, designAudit, comparisonSimilarity, reviewability, dispatchCoherence, claudeHostWiring, modelPolicy, claudeModelPolicy, hostContract: checkHostContract(), interop: checkInterop(options) };
+  const checks = { pluginManifest, hooks, skills, cli, dependencies, runtimeBoundary, fileAudit, gateNotes, designAudit, comparisonSimilarity, reviewability, dispatchCoherence, claudeHostWiring, modelPolicy, claudeModelPolicy, hostContract: checkHostContract(), interop: checkInterop(options), wrapper: checkWrapper(options) };
   return {
     ok: Object.values(checks).every((check) => check.ok),
     checks

--- a/src/wrapper-check.js
+++ b/src/wrapper-check.js
@@ -29,9 +29,12 @@ export function checkWrapper(options = {}) {
     if (located === null) {
       return informational("no Superloopy bin wrapper on PATH (Claude Code, checkout, or not installed) - wrapper currency not tracked", { found: false });
     }
-    const cliPath = parseBinShimCliPath(located.content, platform);
+    const cliPath = located.content === null ? null : parseBinShimCliPath(located.content, platform);
     if (cliPath === null) {
-      return informational(`bin wrapper at ${located.path} is not a recognized Superloopy shim - skipped`, { found: true });
+      // Something other than our generated shim owns the `superloopy` name that resolves first
+      // on PATH (a package-manager or checkout shim). That is what the shell actually runs, so
+      // report it rather than a generated shim later on PATH the user never invokes.
+      return informational(`the \`superloopy\` that resolves first on PATH (${located.path}) is not a Superloopy-generated wrapper - currency not tracked`, { found: true, recognized: false });
     }
     if (!fs.existsSync(cliPath)) {
       return informational(
@@ -55,8 +58,11 @@ export function checkWrapper(options = {}) {
   }
 }
 
-// Find the first PATH entry holding a file named `superloopy` (or `superloopy.cmd`) whose
-// content is one of our generated shims. Returns { path, content } or null.
+// Find the wrapper the shell would actually run: the FIRST PATH entry holding a file named
+// `superloopy` (or `superloopy.cmd`), regardless of its content. Returns { path, content }
+// (content is null when unreadable) or null when no such file is on PATH. The caller decides
+// whether that resolved file is one of our generated shims — scanning past it to a later
+// generated shim would report on a command the user never invokes.
 function locateWrapper(env, platform, fs) {
   const wrapperName = platform === "win32" ? "superloopy.cmd" : "superloopy";
   const rawPath = typeof env.PATH === "string" ? env.PATH : typeof env.Path === "string" ? env.Path : "";
@@ -65,13 +71,20 @@ function locateWrapper(env, platform, fs) {
     const dir = entry.trim().replace(/^"|"$/gu, "");
     if (dir.length === 0) continue;
     const candidate = join(dir, wrapperName);
+    let exists = false;
     try {
-      if (!fs.existsSync(candidate)) continue;
-      const content = fs.readFileSync(candidate, "utf8");
-      if (parseBinShimCliPath(content, platform) !== null) return { path: candidate, content };
+      exists = fs.existsSync(candidate);
     } catch {
-      // Unreadable PATH entry; keep scanning.
+      exists = false;
     }
+    if (!exists) continue;
+    let content = null;
+    try {
+      content = fs.readFileSync(candidate, "utf8");
+    } catch {
+      content = null;
+    }
+    return { path: candidate, content };
   }
   return null;
 }

--- a/src/wrapper-check.js
+++ b/src/wrapper-check.js
@@ -1,0 +1,109 @@
+// Advisory doctor check: does the installed `superloopy` bin wrapper still point at the
+// current version? On Codex marketplace installs the wrapper embeds an ABSOLUTE path into a
+// versioned cache dir (.../superloopy/<version>/src/cli.js), and it is only rewritten when the
+// new version's SessionStart bootstrap re-runs the installer. So right after an upgrade the
+// plugin list can read 0.7.1 while the wrapper still runs the 0.7.0 cache — or points at a
+// pruned cache that no longer exists.
+//
+// This check SURFACES that as a suggestion, never a requirement: it always returns ok:true
+// (informational) so `superloopy doctor`'s overall health never fails just because a newer
+// version is available or the wrapper is stale. It is no-throw and dependency-injectable.
+
+import { existsSync as fsExistsSync, readFileSync as fsReadFileSync, readdirSync as fsReaddirSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { parseBinShimCliPath } from "./agents.js";
+import { compareVersions, parseVersion } from "./auto-update-plan.js";
+
+function informational(message, extra = {}) {
+  return { ok: true, informational: true, message, ...extra };
+}
+
+// Returns a doctor-shaped { ok:true, informational:true, message, ... } result. Never throws.
+export function checkWrapper(options = {}) {
+  try {
+    const env = options.env !== null && typeof options.env === "object" ? options.env : process.env;
+    const platform = options.platform ?? process.platform;
+    const fs = options.fs ?? { existsSync: fsExistsSync, readFileSync: fsReadFileSync, readdirSync: fsReaddirSync };
+
+    const located = locateWrapper(env, platform, fs);
+    if (located === null) {
+      return informational("no Superloopy bin wrapper on PATH (Claude Code, checkout, or not installed) - wrapper currency not tracked", { found: false });
+    }
+    const cliPath = parseBinShimCliPath(located.content, platform);
+    if (cliPath === null) {
+      return informational(`bin wrapper at ${located.path} is not a recognized Superloopy shim - skipped`, { found: true });
+    }
+    if (!fs.existsSync(cliPath)) {
+      return informational(
+        `bin wrapper at ${located.path} points at ${cliPath}, which no longer exists (a marketplace upgrade likely pruned that cached version). The \`superloopy\` command will not run until re-pointed: re-approve the Modified hooks and start a new Codex session, or run \`superloopy bin install --force\` from the current version.`,
+        { found: true, dangling: true, wrapperPath: located.path, cliPath }
+      );
+    }
+    const currency = evaluateWrapperCurrency(cliPath, fs);
+    if (currency.state === "stale") {
+      return informational(
+        `bin wrapper runs superloopy v${currency.wrapperVersion} but v${currency.latestVersion} is installed. Upgrading is optional; to run the newer version, re-approve the Modified hooks and start a new Codex session, or run \`node "${currency.latestCliPath}" bin install --force\`.`,
+        { found: true, stale: true, wrapperPath: located.path, wrapperVersion: currency.wrapperVersion, latestVersion: currency.latestVersion }
+      );
+    }
+    if (currency.state === "untracked") {
+      return informational(`bin wrapper points at a local checkout (${cliPath}); version currency is not tracked for checkout installs`, { found: true });
+    }
+    return informational(`bin wrapper is current (superloopy v${currency.wrapperVersion})`, { found: true, wrapperVersion: currency.wrapperVersion });
+  } catch {
+    return informational("wrapper currency check could not complete");
+  }
+}
+
+// Find the first PATH entry holding a file named `superloopy` (or `superloopy.cmd`) whose
+// content is one of our generated shims. Returns { path, content } or null.
+function locateWrapper(env, platform, fs) {
+  const wrapperName = platform === "win32" ? "superloopy.cmd" : "superloopy";
+  const rawPath = typeof env.PATH === "string" ? env.PATH : typeof env.Path === "string" ? env.Path : "";
+  const sep = platform === "win32" ? ";" : ":";
+  for (const entry of rawPath.split(sep)) {
+    const dir = entry.trim().replace(/^"|"$/gu, "");
+    if (dir.length === 0) continue;
+    const candidate = join(dir, wrapperName);
+    try {
+      if (!fs.existsSync(candidate)) continue;
+      const content = fs.readFileSync(candidate, "utf8");
+      if (parseBinShimCliPath(content, platform) !== null) return { path: candidate, content };
+    } catch {
+      // Unreadable PATH entry; keep scanning.
+    }
+  }
+  return null;
+}
+
+// Decide currency from the versioned-cache layout .../superloopy/<version>/src/cli.js: compare
+// the wrapper's version dir against the newest sibling version dir that still has a cli.js.
+// Returns { state: "current"|"stale"|"untracked", wrapperVersion?, latestVersion?, latestCliPath? }.
+export function evaluateWrapperCurrency(cliPath, fs = { existsSync: fsExistsSync, readdirSync: fsReaddirSync }) {
+  const versionRoot = dirname(dirname(cliPath)); // .../superloopy/<version>
+  const container = dirname(versionRoot); // .../superloopy
+  const wrapperName = basename(versionRoot);
+  const wrapperVersion = parseVersion(wrapperName);
+  if (wrapperVersion === null) return { state: "untracked" };
+  let names;
+  try {
+    names = fs.readdirSync(container);
+  } catch {
+    return { state: "current", wrapperVersion: wrapperName };
+  }
+  let bestVersion = wrapperVersion;
+  let bestName = wrapperName;
+  for (const name of names) {
+    const parsed = parseVersion(name);
+    if (parsed === null) continue;
+    if (!fs.existsSync(join(container, name, "src", "cli.js"))) continue;
+    if (compareVersions(parsed, bestVersion) > 0) {
+      bestVersion = parsed;
+      bestName = name;
+    }
+  }
+  if (compareVersions(bestVersion, wrapperVersion) > 0) {
+    return { state: "stale", wrapperVersion: wrapperName, latestVersion: bestName, latestCliPath: join(container, bestName, "src", "cli.js") };
+  }
+  return { state: "current", wrapperVersion: wrapperName };
+}

--- a/src/wrapper-check.js
+++ b/src/wrapper-check.js
@@ -37,8 +37,14 @@ export function checkWrapper(options = {}) {
       return informational(`the \`superloopy\` that resolves first on PATH (${located.path}) is not a Superloopy-generated wrapper - currency not tracked`, { found: true, recognized: false });
     }
     if (!fs.existsSync(cliPath)) {
+      // The `superloopy` command IS this broken wrapper, so never tell the user to run it. Point
+      // at a surviving sibling cli.js if one exists; otherwise let the bootstrap re-point it.
+      const live = newestLiveSiblingCli(cliPath, fs);
+      const repair = live
+        ? `run \`node "${live}" bin install --force\` to re-point it`
+        : "re-approve the Modified hooks and start a new Codex session so the installer re-points it";
       return informational(
-        `bin wrapper at ${located.path} points at ${cliPath}, which no longer exists (a marketplace upgrade likely pruned that cached version). The \`superloopy\` command will not run until re-pointed: re-approve the Modified hooks and start a new Codex session, or run \`superloopy bin install --force\` from the current version.`,
+        `bin wrapper at ${located.path} points at ${cliPath}, which no longer exists (a marketplace upgrade likely pruned that cached version). The \`superloopy\` command will not run until re-pointed: ${repair}.`,
         { found: true, dangling: true, wrapperPath: located.path, cliPath }
       );
     }
@@ -87,6 +93,32 @@ function locateWrapper(env, platform, fs) {
     return { path: candidate, content };
   }
   return null;
+}
+
+// Given a wrapper's (possibly missing) cli.js, find the newest sibling version dir under the
+// same .../superloopy container whose src/cli.js still exists — a live CLI the repair command
+// can actually invoke. Returns the cli.js path or null when the whole container is gone.
+function newestLiveSiblingCli(cliPath, fs) {
+  const container = dirname(dirname(dirname(cliPath))); // .../superloopy
+  let names;
+  try {
+    names = fs.readdirSync(container);
+  } catch {
+    return null;
+  }
+  let bestCli = null;
+  let bestVersion = null;
+  for (const name of names) {
+    const parsed = parseVersion(name);
+    if (parsed === null) continue;
+    const cli = join(container, name, "src", "cli.js");
+    if (!fs.existsSync(cli)) continue;
+    if (bestVersion === null || compareVersions(parsed, bestVersion) > 0) {
+      bestVersion = parsed;
+      bestCli = cli;
+    }
+  }
+  return bestCli;
 }
 
 // Decide currency from the versioned-cache layout .../superloopy/<version>/src/cli.js: compare

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -9,6 +9,7 @@ import test from "node:test";
 import { normalizeComparisonPath } from "../src/comparison-similarity.js";
 import { formatDoctor, runDoctor } from "../src/doctor.js";
 import { checkWrapper, evaluateWrapperCurrency } from "../src/wrapper-check.js";
+import { parseBinShimCliPath } from "../src/agents.js";
 
 function runCli(args, options = {}) {
   return spawnSync(process.execPath, [join(process.cwd(), "src/cli.js"), ...args], {
@@ -191,6 +192,14 @@ test("evaluateWrapperCurrency ignores a newer version dir with no cli.js", () =>
 function shimFor(cliPath) {
   return `#!/usr/bin/env sh\n# superloopy-generated bin shim\nexec node '${cliPath}' "$@"\n`;
 }
+
+test("parseBinShimCliPath decodes a shell-quoted path containing an apostrophe", () => {
+  // What shellQuote emits for /home/o'connor/superloopy/0.7.1/src/cli.js: interior ' -> '\''.
+  const shim = "#!/usr/bin/env sh\n# superloopy-generated bin shim\nexec node '/home/o'\\''connor/superloopy/0.7.1/src/cli.js' \"$@\"\n";
+  assert.equal(parseBinShimCliPath(shim, "linux"), "/home/o'connor/superloopy/0.7.1/src/cli.js");
+  // A plain path still round-trips unchanged.
+  assert.equal(parseBinShimCliPath(shimFor("/opt/superloopy/0.7.1/src/cli.js"), "linux"), "/opt/superloopy/0.7.1/src/cli.js");
+});
 
 test("checkWrapper reports a stale wrapper as an optional suggestion", () => {
   const { superloopyDir, binDir, cliOf } = slPaths("wrktest");

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -224,6 +224,29 @@ test("checkWrapper reports a dangling wrapper after a pruned cache", () => {
   assert.match(result.message, /no longer exists/);
 });
 
+test("checkWrapper reports the first-resolved wrapper, not a later generated shim", () => {
+  const early = slPaths("earlyroot");
+  const late = slPaths("lateroot");
+  const earlyWrapper = join(early.binDir, "superloopy"); // a foreign shim, resolves FIRST on PATH
+  const lateWrapper = join(late.binDir, "superloopy"); // our generated (stale) shim, later on PATH
+  const files = {
+    [earlyWrapper]: "#!/bin/sh\nexec some-other-tool \"$@\"\n",
+    [lateWrapper]: shimFor(late.cliOf("0.7.0")),
+    [late.cliOf("0.7.0")]: "x",
+    [late.cliOf("0.7.1")]: "x"
+  };
+  const fs = {
+    existsSync: (p) => p in files || p === late.superloopyDir,
+    readFileSync: (p) => { if (!(p in files)) throw new Error("ENOENT"); return files[p]; },
+    readdirSync: (p) => { if (p !== late.superloopyDir) throw new Error("ENOENT"); return ["0.7.0", "0.7.1"]; }
+  };
+  const result = checkWrapper({ env: { PATH: `${early.binDir}:${late.binDir}` }, platform: "linux", fs });
+  assert.equal(result.ok, true);
+  assert.equal(result.found, true);
+  assert.equal(result.recognized, false); // the winning PATH entry is not our shim
+  assert.doesNotMatch(result.message, /is installed/); // must NOT report the later shim as stale
+});
+
 test("checkWrapper stays silent when no wrapper is on PATH", () => {
   const fs = { existsSync: () => false, readFileSync: () => "", readdirSync: () => [] };
   const result = checkWrapper({ env: { PATH: "/nowhere" }, platform: "linux", fs });

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -8,6 +8,7 @@ import test from "node:test";
 
 import { normalizeComparisonPath } from "../src/comparison-similarity.js";
 import { formatDoctor, runDoctor } from "../src/doctor.js";
+import { checkWrapper, evaluateWrapperCurrency } from "../src/wrapper-check.js";
 
 function runCli(args, options = {}) {
   return spawnSync(process.execPath, [join(process.cwd(), "src/cli.js"), ...args], {
@@ -90,7 +91,8 @@ test("doctor --json reports Superloopy packaging, audit, and reviewability check
     "modelPolicy",
     "claudeModelPolicy",
     "hostContract",
-    "interop"
+    "interop",
+    "wrapper"
   ]);
   assert.equal(parsed.checks.pluginManifest.ok, true);
   assert.equal(parsed.checks.hooks.ok, true);
@@ -136,6 +138,87 @@ test("doctor --json reports Superloopy packaging, audit, and reviewability check
   assert.equal(parsed.checks.interop.ok, true);
   assert.equal(parsed.checks.interop.informational, true);
   assert.equal(typeof parsed.checks.interop.installed, "boolean");
+  // Wrapper currency is advisory: upgrade is a suggestion, so it never gates health.
+  assert.equal(parsed.checks.wrapper.ok, true);
+  assert.equal(parsed.checks.wrapper.informational, true);
+});
+
+test("evaluateWrapperCurrency flags a stale versioned cache but not a current or checkout one", () => {
+  const files = new Set([
+    "/c/superloopy/0.7.0/src/cli.js",
+    "/c/superloopy/0.7.1/src/cli.js"
+  ]);
+  const dirs = { "/c/superloopy": ["0.7.0", "0.7.1"] };
+  const fs = {
+    existsSync: (p) => files.has(p),
+    readdirSync: (p) => { if (!(p in dirs)) throw new Error("ENOENT"); return dirs[p]; }
+  };
+  const stale = evaluateWrapperCurrency("/c/superloopy/0.7.0/src/cli.js", fs);
+  assert.equal(stale.state, "stale");
+  assert.equal(stale.wrapperVersion, "0.7.0");
+  assert.equal(stale.latestVersion, "0.7.1");
+  assert.equal(stale.latestCliPath, "/c/superloopy/0.7.1/src/cli.js");
+
+  const current = evaluateWrapperCurrency("/c/superloopy/0.7.1/src/cli.js", fs);
+  assert.equal(current.state, "current");
+
+  // A checkout path (no parseable version dir) is not version-tracked.
+  const checkout = evaluateWrapperCurrency("/home/dev/loopy/src/cli.js", {
+    existsSync: () => true,
+    readdirSync: () => { throw new Error("unused"); }
+  });
+  assert.equal(checkout.state, "untracked");
+});
+
+test("evaluateWrapperCurrency ignores a newer version dir with no cli.js", () => {
+  const files = new Set(["/c/superloopy/0.7.0/src/cli.js"]); // 0.8.0 dir exists but has no cli.js
+  const dirs = { "/c/superloopy": ["0.7.0", "0.8.0"] };
+  const fs = { existsSync: (p) => files.has(p), readdirSync: (p) => dirs[p] };
+  assert.equal(evaluateWrapperCurrency("/c/superloopy/0.7.0/src/cli.js", fs).state, "current");
+});
+
+function shimFor(cliPath) {
+  return `#!/usr/bin/env sh\n# superloopy-generated bin shim\nexec node '${cliPath}' "$@"\n`;
+}
+
+test("checkWrapper reports a stale wrapper as an optional suggestion", () => {
+  const files = {
+    "/bin/superloopy": shimFor("/c/superloopy/0.7.0/src/cli.js"),
+    "/c/superloopy/0.7.0/src/cli.js": "x",
+    "/c/superloopy/0.7.1/src/cli.js": "x"
+  };
+  const dirs = { "/c/superloopy": ["0.7.0", "0.7.1"] };
+  const fs = {
+    existsSync: (p) => p in files || p in dirs,
+    readFileSync: (p) => { if (!(p in files)) throw new Error("ENOENT"); return files[p]; },
+    readdirSync: (p) => { if (!(p in dirs)) throw new Error("ENOENT"); return dirs[p]; }
+  };
+  const result = checkWrapper({ env: { PATH: "/bin" }, platform: "linux", fs });
+  assert.equal(result.ok, true);
+  assert.equal(result.informational, true);
+  assert.equal(result.stale, true);
+  assert.match(result.message, /v0\.7\.1 is installed/);
+  assert.match(result.message, /optional/i);
+});
+
+test("checkWrapper reports a dangling wrapper after a pruned cache", () => {
+  const files = { "/bin/superloopy": shimFor("/c/superloopy/0.7.0/src/cli.js") }; // cli.js gone
+  const fs = {
+    existsSync: (p) => p in files,
+    readFileSync: (p) => { if (!(p in files)) throw new Error("ENOENT"); return files[p]; },
+    readdirSync: () => { throw new Error("ENOENT"); }
+  };
+  const result = checkWrapper({ env: { PATH: "/bin" }, platform: "linux", fs });
+  assert.equal(result.ok, true);
+  assert.equal(result.dangling, true);
+  assert.match(result.message, /no longer exists/);
+});
+
+test("checkWrapper stays silent when no wrapper is on PATH", () => {
+  const fs = { existsSync: () => false, readFileSync: () => "", readdirSync: () => [] };
+  const result = checkWrapper({ env: { PATH: "/nowhere" }, platform: "linux", fs });
+  assert.equal(result.ok, true);
+  assert.equal(result.found, false);
 });
 
 test("doctor model policy fails when bundled agent defaults drift", async () => {

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -143,27 +143,35 @@ test("doctor --json reports Superloopy packaging, audit, and reviewability check
   assert.equal(parsed.checks.wrapper.informational, true);
 });
 
-test("evaluateWrapperCurrency flags a stale versioned cache but not a current or checkout one", () => {
-  const files = new Set([
-    "/c/superloopy/0.7.0/src/cli.js",
-    "/c/superloopy/0.7.1/src/cli.js"
-  ]);
-  const dirs = { "/c/superloopy": ["0.7.0", "0.7.1"] };
-  const fs = {
-    existsSync: (p) => files.has(p),
-    readdirSync: (p) => { if (!(p in dirs)) throw new Error("ENOENT"); return dirs[p]; }
+// Build paths with node:path.join so the fake-fs keys match what the module computes on the
+// host platform (win32 uses backslashes) — the earlier hardcoded POSIX literals only matched
+// on non-Windows. Colon-free segments keep the linux-mode PATH split (`:`) intact.
+function slPaths(root) {
+  const superloopyDir = join(root, "cache", "superloopy");
+  return {
+    superloopyDir,
+    binDir: join(root, "bin"),
+    cliOf: (version) => join(superloopyDir, version, "src", "cli.js")
   };
-  const stale = evaluateWrapperCurrency("/c/superloopy/0.7.0/src/cli.js", fs);
+}
+
+test("evaluateWrapperCurrency flags a stale versioned cache but not a current or checkout one", () => {
+  const { superloopyDir, cliOf } = slPaths("wrktest");
+  const present = new Set([cliOf("0.7.0"), cliOf("0.7.1")]);
+  const fs = {
+    existsSync: (p) => present.has(p),
+    readdirSync: (p) => { if (p !== superloopyDir) throw new Error("ENOENT"); return ["0.7.0", "0.7.1"]; }
+  };
+  const stale = evaluateWrapperCurrency(cliOf("0.7.0"), fs);
   assert.equal(stale.state, "stale");
   assert.equal(stale.wrapperVersion, "0.7.0");
   assert.equal(stale.latestVersion, "0.7.1");
-  assert.equal(stale.latestCliPath, "/c/superloopy/0.7.1/src/cli.js");
+  assert.equal(stale.latestCliPath, cliOf("0.7.1"));
 
-  const current = evaluateWrapperCurrency("/c/superloopy/0.7.1/src/cli.js", fs);
-  assert.equal(current.state, "current");
+  assert.equal(evaluateWrapperCurrency(cliOf("0.7.1"), fs).state, "current");
 
   // A checkout path (no parseable version dir) is not version-tracked.
-  const checkout = evaluateWrapperCurrency("/home/dev/loopy/src/cli.js", {
+  const checkout = evaluateWrapperCurrency(join("home", "dev", "loopy", "src", "cli.js"), {
     existsSync: () => true,
     readdirSync: () => { throw new Error("unused"); }
   });
@@ -171,10 +179,13 @@ test("evaluateWrapperCurrency flags a stale versioned cache but not a current or
 });
 
 test("evaluateWrapperCurrency ignores a newer version dir with no cli.js", () => {
-  const files = new Set(["/c/superloopy/0.7.0/src/cli.js"]); // 0.8.0 dir exists but has no cli.js
-  const dirs = { "/c/superloopy": ["0.7.0", "0.8.0"] };
-  const fs = { existsSync: (p) => files.has(p), readdirSync: (p) => dirs[p] };
-  assert.equal(evaluateWrapperCurrency("/c/superloopy/0.7.0/src/cli.js", fs).state, "current");
+  const { superloopyDir, cliOf } = slPaths("wrktest");
+  const present = new Set([cliOf("0.7.0")]); // 0.8.0 dir is listed but has no cli.js
+  const fs = {
+    existsSync: (p) => present.has(p),
+    readdirSync: (p) => (p === superloopyDir ? ["0.7.0", "0.8.0"] : [])
+  };
+  assert.equal(evaluateWrapperCurrency(cliOf("0.7.0"), fs).state, "current");
 });
 
 function shimFor(cliPath) {
@@ -182,18 +193,15 @@ function shimFor(cliPath) {
 }
 
 test("checkWrapper reports a stale wrapper as an optional suggestion", () => {
-  const files = {
-    "/bin/superloopy": shimFor("/c/superloopy/0.7.0/src/cli.js"),
-    "/c/superloopy/0.7.0/src/cli.js": "x",
-    "/c/superloopy/0.7.1/src/cli.js": "x"
-  };
-  const dirs = { "/c/superloopy": ["0.7.0", "0.7.1"] };
+  const { superloopyDir, binDir, cliOf } = slPaths("wrktest");
+  const wrapperPath = join(binDir, "superloopy");
+  const files = { [wrapperPath]: shimFor(cliOf("0.7.0")), [cliOf("0.7.0")]: "x", [cliOf("0.7.1")]: "x" };
   const fs = {
-    existsSync: (p) => p in files || p in dirs,
+    existsSync: (p) => p in files || p === superloopyDir,
     readFileSync: (p) => { if (!(p in files)) throw new Error("ENOENT"); return files[p]; },
-    readdirSync: (p) => { if (!(p in dirs)) throw new Error("ENOENT"); return dirs[p]; }
+    readdirSync: (p) => { if (p !== superloopyDir) throw new Error("ENOENT"); return ["0.7.0", "0.7.1"]; }
   };
-  const result = checkWrapper({ env: { PATH: "/bin" }, platform: "linux", fs });
+  const result = checkWrapper({ env: { PATH: binDir }, platform: "linux", fs });
   assert.equal(result.ok, true);
   assert.equal(result.informational, true);
   assert.equal(result.stale, true);
@@ -202,13 +210,15 @@ test("checkWrapper reports a stale wrapper as an optional suggestion", () => {
 });
 
 test("checkWrapper reports a dangling wrapper after a pruned cache", () => {
-  const files = { "/bin/superloopy": shimFor("/c/superloopy/0.7.0/src/cli.js") }; // cli.js gone
+  const { binDir, cliOf } = slPaths("wrktest");
+  const wrapperPath = join(binDir, "superloopy");
+  const files = { [wrapperPath]: shimFor(cliOf("0.7.0")) }; // cli.js gone
   const fs = {
     existsSync: (p) => p in files,
     readFileSync: (p) => { if (!(p in files)) throw new Error("ENOENT"); return files[p]; },
     readdirSync: () => { throw new Error("ENOENT"); }
   };
-  const result = checkWrapper({ env: { PATH: "/bin" }, platform: "linux", fs });
+  const result = checkWrapper({ env: { PATH: binDir }, platform: "linux", fs });
   assert.equal(result.ok, true);
   assert.equal(result.dangling, true);
   assert.match(result.message, /no longer exists/);

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -231,6 +231,24 @@ test("checkWrapper reports a dangling wrapper after a pruned cache", () => {
   assert.equal(result.ok, true);
   assert.equal(result.dangling, true);
   assert.match(result.message, /no longer exists/);
+  // The broken wrapper cannot repair itself; with no live sibling, point at the bootstrap.
+  assert.match(result.message, /re-approve the Modified hooks/);
+  assert.doesNotMatch(result.message, /`superloopy bin install/);
+});
+
+test("checkWrapper points a dangling wrapper at a surviving sibling cli, not itself", () => {
+  const { superloopyDir, binDir, cliOf } = slPaths("wrktest");
+  const wrapperPath = join(binDir, "superloopy");
+  const files = { [wrapperPath]: shimFor(cliOf("0.7.0")), [cliOf("0.7.1")]: "x" }; // 0.7.0 pruned, 0.7.1 live
+  const fs = {
+    existsSync: (p) => p in files,
+    readFileSync: (p) => { if (!(p in files)) throw new Error("ENOENT"); return files[p]; },
+    readdirSync: (p) => { if (p !== superloopyDir) throw new Error("ENOENT"); return ["0.7.0", "0.7.1"]; }
+  };
+  const result = checkWrapper({ env: { PATH: binDir }, platform: "linux", fs });
+  assert.equal(result.dangling, true);
+  assert.match(result.message, /node ".*0\.7\.1.*cli\.js" bin install --force/); // a runnable live CLI
+  assert.doesNotMatch(result.message, /`superloopy bin install/);
 });
 
 test("checkWrapper reports the first-resolved wrapper, not a later generated shim", () => {


### PR DESCRIPTION
## Summary

Adds an **advisory** doctor check that surfaces a common post-upgrade confusion on Codex: `plugin list` reads the new version, but the `superloopy` / `superloopy.cmd` wrapper still runs the old one.

**Why it happens:** on marketplace installs the wrapper embeds an *absolute* path into a versioned cache dir (`.../superloopy/<version>/src/cli.js`) and is only rewritten when the new version's `SessionStart` bootstrap re-runs the installer (which needs Modified-hook re-approval + a fresh session). Until then the wrapper runs the old cache — or points at a cache that a prune already deleted.

## Design: a suggestion, never a requirement

The check is **informational and always `ok: true`** (mirrors `checkInterop`), so `superloopy doctor`'s overall health never fails just because a newer version is available. Upgrading stays optional; the check only *tells you* and hands you the exact fix.

- **dangling** — the wrapper's `cli.js` no longer exists (pruned cache): the command is broken; re-approve hooks + restart, or `superloopy bin install --force`.
- **stale** — a newer version dir exists in the cache: "Upgrading is optional; to run the newer version, …".
- **current / untracked / no-wrapper** — quiet.

Codex-scoped (skips when no wrapper is on PATH, e.g. Claude Code or checkout installs), **no-throw**, and fully dependency-injectable (`env` / `platform` / `fs`).

## Changes

- `src/wrapper-check.js` (new) — `checkWrapper()` + pure `evaluateWrapperCurrency()`.
- `src/agents.js` — export `parseBinShimCliPath()` to read where a generated shim points.
- `src/doctor.js` — wire in the `wrapper` check; compacted the `checkFileAudit` call to stay within the 500-line reviewability budget.
- `docs/superloopy-file-audit.md`, `docs/superloopy-loop-golden-set.md` — inventory rows for the new file.
- `test/doctor.test.js` — unit tests for stale / dangling / current / untracked / no-wrapper, plus the doctor keys + informational assertions.

## Verification

- `npm test` — **330 passing**.
- `doctor --json` — overall **ok: true**; new `wrapper` check present and informational.
- Reproduced the reported scenario (wrapper → `0.7.0` cache while `0.7.1` is installed): detected as `stale`, `ok: true`, with "Upgrading is optional" + the exact `bin install --force` command.

## Notes

- **No version bump** in this branch, to avoid colliding with the `0.7.1` in #11 — sequence the bump at merge time.
- Independent of #11 (based on `main`).
- Follow-up (not here): the deeper cure is a version-independent install root / indirection so the wrapper never pins a versioned cache path; larger change.
