### PR TITLE
Improve doctor root resolution and bundled skill checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "superloopy",
       "source": "./",
       "description": "Strict evidence loop harness: repo-local loop state, success criteria, append-only ledgers, evidence-gated completion, plus skills (loop, research, frontend, clone) and a read-only/worker crew. Works on Claude Code and Codex from one repo.",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Lightweight loop harness with strict evidence gates — Claude Code edition.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Lightweight loop harness with strict evidence gates.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/docs/superloopy-file-audit.md
+++ b/docs/superloopy-file-audit.md
@@ -195,12 +195,13 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 | `src/begin.js` | One-command entrypoint that creates a plan and starts the first goal. | Superloopy-specific ease-of-start flow. |
 | `src/capture.js` | Runs validation commands and records transcript artifacts as pass/fail evidence. | Superloopy evidence convenience layer. |
 | `src/check.js` | Non-mutating evidence preflight with summary counts, warnings, repair plan, and exact commands. | Superloopy-only strictness layer. |
-| `src/cli.js` | Single command dispatcher for install, loop, bin, agents, doctor, hook entrypoints, and handoff/fleet text output; supports symlinked bin execution. | Public doctor scan uses generic comparison paths; install writes only local wrapper and agent files; crew lines remain presentation-only. |
+| `src/cli.js` | Single command dispatcher for install, loop, bin, agents, doctor, hook entrypoints, and handoff/fleet text output; supports symlinked bin execution. | Public doctor scan uses generic comparison paths and resolves the checked plugin root explicitly; install writes only local wrapper and agent files; crew lines remain presentation-only. |
 | `src/comparison-similarity.js` | Optional copied-block scanner against a caller-provided folder. | Generic comparison; no named source coupling. |
 | `src/continuation.js` | Bounded, progress-gated Stop-hook engine that drives the loop toward evidence-backed completion and marks blocked on a cap or stall. | Superloopy-native continuation; never force-completes. |
 | `src/crew-lines.js` | Deterministic original localized one-line responses for known crew handoffs with terminal verdicts. | Output-only flavor; pending or unknown lanes stay silent and persisted handoff state is not decorated. |
 | `src/design-audit.js` | Verifies Superloopy design audit sections and decision rows. | Guards Superloopy-native decisions. |
-| `src/doctor.js` | Local health check orchestrator for package, hooks, Claude host wiring, docs, comparison scan, Codex + Claude model policy, reviewability, and advisory bin wrapper currency. | Enforces file audits, design audits, Claude host wiring, and advisory model defaults on both hosts. |
+| `src/doctor.js` | Local health check orchestrator for package, hooks, Claude host wiring, docs, comparison scan, Codex + Claude model policy, reviewability, and advisory bin wrapper currency. | Enforces file audits, design audits, Claude host wiring, bundled skill coverage, and advisory model defaults on both hosts. |
+| `src/doctor-skills.js` | Bundled skill-directory verifier used by doctor. | Requires every shipped skill to exist and validates each `SKILL.md` frontmatter name without host-specific state. |
 | `src/engineer.js` | Loop-engineer trigger that turns the `loopy` keyword (and Korean alias `루피`) into a guided drive of begin, prove, check, and finish, plus guidance-only frontend and Korean-writing steers. | Superloopy keyword activation and guide-backed context. |
 | `src/file-audit.js` | Row-level file inventory verifier for audit coverage, stale rows, incomplete rows, and native boundary policy. | Checks Superloopy audit structure. |
 | `src/finish.js` | One-command finalization that writes the default gate, checkpoints remaining goals, writes the report, and returns the complete guide. | Superloopy-specific lighter flow. |
@@ -236,6 +237,7 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 | `test/crew-lines.test.js` | Unit and CLI coverage for presentation-only localized crew completion lines. | Prevents crew flavor from replacing status or speaking for pending/unknown lanes. |
 | `test/docs.test.js` | Public documentation contract tests for Superloopy-native docs and threshold history. | Keeps docs aligned with product contract. |
 | `test/doctor.test.js` | Doctor coverage for package, audit, comparison, design audit, and reviewability checks. | Uses synthetic fixtures only. |
+| `test/doctor-review-feedback.test.js` | Regression tests for PR review hardening around doctor root selection and corrupt skills paths. | Superloopy-native review-feedback coverage only. |
 | `test/file-audit.test.js` | Direct unit coverage for row-level file audit verifier. | Tests Superloopy audit parser. |
 | `test/humanize-korean.test.js` | Contract tests for the Korean humanizer audit script's accept and reject paths. | Superloopy-native test for dependency-free safeguards and protected-token gating. |
 | `test/fleet.test.js` | Handoff registry, fleet reconciliation, verdict-normalization, and crew-line decoration tests. | Tests Superloopy parent-side coordination without persisting presentation flavor. |
@@ -270,7 +272,7 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 
 ## Weight Notes
 
-- Current largest source file: `src/doctor.js`, at the reviewability cap (500 lines). Keep new checks in helper modules (for example `src/interop.js` holds `checkInterop`) rather than growing `doctor.js` past the cap.
+- Current largest source file: `src/hooks.js`, below the reviewability cap (500 lines). Keep new checks in helper modules (for example `src/interop.js` holds `checkInterop` and `src/doctor-skills.js` holds bundled skill checks) rather than growing orchestrators past the cap.
 - No package dependencies are added; `package.json` stays dependency-free and `superloopy doctor --json` checks that boundary.
 - Marketplace update checks are advisory and self-update only runs for a future npx-local snapshot; current marketplace and checkout installs keep their documented update commands.
 - Runtime state is ignored under `.superloopy/`; `superloopy doctor --json` verifies runtime samples are ignored and not tracked.

--- a/docs/superloopy-loop-golden-set.md
+++ b/docs/superloopy-loop-golden-set.md
@@ -45,7 +45,7 @@ Total: 100 points.
 | LG-03 | Hooks keep long-running work from ending early. | `node --test test/hooks.test.js test/golden-hooks.test.js` | Stop, prompt, receipt, scoped session, and steering hooks are fail-closed and guide-backed. |
 | LG-04 | Goal parsing and scoped state stay stable across turns. | `node --test test/goals.test.js test/golden-matrix-gate.test.js` | `@goal` stories, scoped sessions, and matrix gate rows remain deterministic. |
 | LG-05 | Quality gates reject weak proof. | `node --test test/golden-review-gate.test.js test/golden-matrix-gate.test.js test/loop-gates.test.js` | Weak QA, not-applicable shortcuts, missing matrix rows, and inline-only proof fail. |
-| LG-06 | Public docs and packaging stay executable. | `node --test test/docs.test.js test/plugin.test.js test/doctor.test.js` | Docs describe the real command surface, plugin hooks are valid, and doctor remains dependency-free. |
+| LG-06 | Public docs and packaging stay executable. | `node --test test/docs.test.js test/plugin.test.js test/doctor.test.js test/doctor-review-feedback.test.js` | Docs describe the real command surface, plugin hooks are valid, and doctor remains dependency-free. |
 | LG-07 | Whole-repo health stays strict. | `npm test` and `node src/cli.js doctor --json` | All tests pass, doctor reports `ok: true`, and no file exceeds the reviewability limit. |
 | LG-08 | The continuation engine drives bounded multi-iteration work to evidence-backed completion. | `node --test test/golden-continuation.test.js` | Blocks while incomplete and under budget, resets the stall counter only above a recorded-proof high-water mark, and stops blocked-not-complete on a cap or no-progress; aggregate completion clears loop-control state. |
 | LG-09 | Crew completion lines stay localized and presentation-only. | `node --test test/crew-lines.test.js test/fleet.test.js` | Terminal known crew handoffs may speak once in a supported catalog language, pending/unknown lanes stay quiet, and evidence/status fields remain authoritative. |
@@ -237,12 +237,13 @@ Total: 100 points.
 | `src/begin.js` | CLI begin tests. | Must create a plan, start the first goal, and return an immediate proof guide. |
 | `src/capture.js` | CLI evidence tests. | Must write command transcripts and mark pass/fail from command exit status. |
 | `src/check.js` | Loop-gate and CLI evidence tests. | Must be non-mutating and print warnings plus repair commands for every unresolved or invalid proof. |
-| `src/cli.js` | CLI, plugin, doctor, and crew-line tests. | Must dispatch install, loop, bin, agents, doctor, hook commands, generic comparison-check flags, symlinked bin execution, and status-safe handoff/fleet text. |
+| `src/cli.js` | CLI, plugin, doctor, and crew-line tests. | Must dispatch install, loop, bin, agents, doctor, hook commands, generic comparison-check flags, symlinked bin execution, doctor-root resolution, and status-safe handoff/fleet text. |
 | `src/comparison-similarity.js` | Doctor comparison tests. | Must compare code-shaped files only when an explicit comparison path is provided. |
 | `src/continuation.js` | `test/golden-continuation.test.js`. | Must drive bounded continuation toward evidence-backed completion and mark blocked (never complete) on a cap or stall. |
 | `src/crew-lines.js` | `test/crew-lines.test.js`, `test/fleet.test.js`. | Must generate original deterministic supported-catalog lines only for known terminal crew handoffs and format them without mutating persisted state. |
 | `src/design-audit.js` | Doctor design-audit tests. | Must fail missing sections, decisions, or incomplete guards. |
-| `src/doctor.js` | `test/doctor.test.js`, `test/claude-host-wiring.test.js`, `node src/cli.js doctor --json`. | Must verify package, hooks, Claude host wiring, skill, audits, comparison status, Codex + Claude model policy, and reviewability while ignoring generated Codex marketplace install metadata. |
+| `src/doctor.js` | `test/doctor.test.js`, `test/claude-host-wiring.test.js`, `node src/cli.js doctor --json`. | Must verify package, hooks, Claude host wiring, bundled skills, audits, comparison status, Codex + Claude model policy, and reviewability while ignoring generated Codex marketplace install metadata. |
+| `src/doctor-skills.js` | `test/doctor.test.js`, `test/doctor-review-feedback.test.js`, `node src/cli.js doctor --json`. | Must require every shipped skill directory, validate each `SKILL.md` frontmatter name, and return structured failures for unreadable skill paths. |
 | `src/engineer.js` | `test/engineer.test.js`, `test/hooks.test.js` engineer-trigger tests. | Must wake the loop engineer on a leading `loopy` keyword or its Korean alias `루피` without mutating state itself, escalate to crew fan-out only on `team`/`crew`/`팀`/`크루`, and detect frontend/visual or Korean-writing intent for guidance-only skill steers. |
 | `src/file-audit.js` | `test/file-audit.test.js`, doctor file-audit check. | Must fail missing, stale, or incomplete inventory rows. |
 | `src/finish.js` | CLI evidence and loop-gate tests. | Must only finalize after all criteria have valid pass artifacts, then write gate and report artifacts. |
@@ -278,6 +279,7 @@ Total: 100 points.
 | `test/crew-lines.test.js` | `npm test`. | Must prove crew completion lines are original deterministic localized presentation, pending/unknown lanes stay silent, and CLI status remains visible. |
 | `test/docs.test.js` | `npm test`. | Must keep README, skill, gate notes, design audit, and this golden set aligned with enforced behavior. |
 | `test/doctor.test.js` | `npm test`. | Must cover doctor checks for package, audits, comparison, design decisions, model policy, generated install metadata, and reviewability. |
+| `test/doctor-review-feedback.test.js` | `npm test`. | Must cover review-requested doctor hardening for broken checkout manifests and non-directory skills paths. |
 | `test/file-audit.test.js` | `npm test`. | Must prove the file-audit verifier fails stale inventory rows. |
 | `test/humanize-korean.test.js` | `node --test test/humanize-korean.test.js`. | Must prove the Korean humanizer audit script accepts preserved Korean output and rejects non-Korean or token-dropping output. |
 | `test/fleet.test.js` | `npm test`. | Must prove verdict normalization, artifact-bound accept verdicts, handoff recording/update, fleet reconciliation, crew-line decoration, and the parallel-cap warning. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superloopy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superloopy",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "bin": {
         "superloopy": "src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A lightweight loop harness for Codex and Claude Code with strict evidence gates.",
   "type": "module",
   "bin": {

--- a/skills/superloopy-doctor/SKILL.md
+++ b/skills/superloopy-doctor/SKILL.md
@@ -19,14 +19,14 @@ This is a Superloopy health check, not a generic plugin drift audit.
 - Treat loop commands as the behavioral truth surface, but keep their limits clear: `superloopy loop status --json`, `superloopy loop check`, `superloopy loop guide --json`, and evidence files under `.superloopy/evidence/` can show current plan and artifact readiness.
 - Read the installed plugin cache only to identify which Superloopy code the wrapper runs.
 - Do not clone external repos, search issue trackers, or compare unrelated harness layouts unless the user separately asks for research.
-- Do not diagnose from an arbitrary cwd. If `doctor` reports missing `.codex-plugin/plugin.json`, rerun from the checkout or installed plugin cache before calling Superloopy broken.
+- `superloopy doctor` reports the plugin root it checked: by default it uses the current directory when that is a Superloopy checkout, otherwise it checks the installed CLI root. Use `superloopy doctor --root <checkout-or-cache> --json` when you need to pin the target explicitly.
 
 ## Diagnostic Spine
 
 1. Identify the target root: `pwd`, `git rev-parse --show-toplevel` when it is a checkout, and the installed plugin cache path when the wrapper points into one.
 2. Locate the user-visible command: `command -v superloopy`, `which -a superloopy`, and the wrapper text or symlink target.
 3. Inspect Codex registry state with `codex plugin list --json` when Codex is available; use it only to locate `superloopy@beefiker` and its version.
-4. Run `superloopy doctor --json`. If the wrapper is missing or stale, run `node src/cli.js doctor --json` from the checkout or installed cache being evaluated.
+4. Run `superloopy doctor --json` and record the reported `root`. If the wrapper is missing or stale, run `node src/cli.js doctor --root <checkout-or-cache> --json` from the checkout or installed cache being evaluated.
 5. Read the named doctor checks, especially `skills`, `fileAudit`, `reviewability`, `dispatchCoherence`, `hostContract`, `modelPolicy`, and `claudeHostWiring`.
 6. Probe loop readiness without changing state: use `superloopy loop status --json` if a plan exists, otherwise note "no active plan" instead of creating one. Use `superloopy loop check` only to validate trace/artifact readiness for an existing plan; read-only diagnosis cannot prove completion safety because it does not re-run recorded commands. If the user asks whether completion is actually safe, point at the real gates: `superloopy loop review`, `superloopy loop checkpoint`, or `superloopy loop finish`.
 7. Verify crew install shape by name: `franky`, `zoro`, `usopp`, `jinbe`, `robin`, and `nami`; judge by files and doctor checks, not by role labels alone.

--- a/skills/superloopy-loop/SKILL.md
+++ b/skills/superloopy-loop/SKILL.md
@@ -211,6 +211,6 @@ After any accepted steering, follow the returned guide; run `superloopy loop sta
 
 ## Doctor
 
-`superloopy doctor --json` checks the package, hooks, skill, CLI, dependency-free boundary, runtime ignore policy, file inventory, gate notes, design audit, generic comparison scan status, dispatch coherence, model policy, and reviewability.
+`superloopy doctor --json` checks the package, hooks, bundled skills, CLI, dependency-free boundary, runtime ignore policy, file inventory, gate notes, design audit, generic comparison scan status, dispatch coherence, model policy, and reviewability.
 
 Use `superloopy doctor --comparison-path /path/to/comparison --json` only when you need copied-block evidence against an external folder. The generic comparison scan compares code-shaped files for substantial contiguous blocks without naming or coupling Superloopy to any source project.

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hasFlag, parseJson, readFlag, readStdin } from "./args.js";
@@ -124,7 +124,22 @@ function resolveDoctorRoot(cwd, argv) {
 }
 
 function isLikelySuperloopyPluginRoot(cwd) {
-  return existsSync(join(cwd, ".codex-plugin")) && existsSync(join(cwd, "src", "cli.js"));
+  if (!existsSync(join(cwd, ".codex-plugin")) || !existsSync(join(cwd, "src", "cli.js"))) {
+    return false;
+  }
+  // Identify Superloopy by package identity, not the .codex-plugin manifest: a real
+  // checkout with a broken/wrong-name plugin.json still gets diagnosed (so its
+  // pluginManifest check can fail), while an unrelated Codex plugin project falls
+  // back to CLI_ROOT instead of collecting Superloopy-specific false failures.
+  return readPackageName(cwd) === "superloopy";
+}
+
+function readPackageName(cwd) {
+  try {
+    return JSON.parse(readFileSync(join(cwd, "package.json"), "utf8")).name;
+  } catch {
+    return null;
+  }
 }
 
 async function runLoop(subcommand, argv, stdout, cwd) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hasFlag, parseJson, readFlag, readStdin } from "./args.js";
 import {
@@ -40,6 +41,9 @@ import {
   runSubagentStopHook,
   runUserPromptSubmitHook
 } from "./hooks.js";
+
+const CLI_FILE = fileURLToPath(import.meta.url);
+const CLI_ROOT = dirname(dirname(CLI_FILE));
 
 async function main(argv, stdin, stdout, stderr, cwd) {
   const [command, subcommand, ...rest] = argv;
@@ -108,9 +112,19 @@ async function runInstall(argv, stdout, cwd) {
 async function runDoctorCommand(argv, stdout, cwd) {
   const json = hasFlag(argv, "--json");
   const comparisonPath = readFlag(argv, "--comparison-path");
-  const result = await runDoctor(cwd, { comparisonPath });
+  const result = await runDoctor(resolveDoctorRoot(cwd, argv), { comparisonPath });
   stdout.write(json ? `${JSON.stringify(result, null, 2)}\n` : formatDoctor(result));
   return result.ok ? 0 : 1;
+}
+
+function resolveDoctorRoot(cwd, argv) {
+  const explicit = readFlag(argv, "--root") ?? readFlag(argv, "--plugin-root");
+  if (explicit !== undefined) return resolve(cwd, explicit);
+  return isLikelySuperloopyPluginRoot(cwd) ? cwd : CLI_ROOT;
+}
+
+function isLikelySuperloopyPluginRoot(cwd) {
+  return existsSync(join(cwd, ".codex-plugin")) && existsSync(join(cwd, "src", "cli.js"));
 }
 
 async function runLoop(subcommand, argv, stdout, cwd) {
@@ -251,7 +265,7 @@ function topHelp() {
     "  superloopy install [--bin-dir PATH] [--target PATH] [--force] [--json]",
     "  superloopy bin install [--bin-dir PATH] [--force] [--json]",
     "  superloopy agents install [--target PATH] [--force] [--json]",
-    "  superloopy doctor [--json] [--comparison-path PATH]",
+    "  superloopy doctor [--json] [--root PATH] [--comparison-path PATH]",
     "  superloopy hook session-start|pre-tool-use|stop|subagent-stop|user-prompt-submit",
     "",
     helpText()
@@ -292,8 +306,8 @@ export { main };
 function isDirectCliInvocation() {
   if (process.argv[1] === undefined) return false;
   try {
-    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+    return realpathSync(process.argv[1]) === CLI_FILE;
   } catch {
-    return process.argv[1] === fileURLToPath(import.meta.url);
+    return process.argv[1] === CLI_FILE;
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hasFlag, parseJson, readFlag, readStdin } from "./args.js";
@@ -124,20 +124,30 @@ function resolveDoctorRoot(cwd, argv) {
 }
 
 function isLikelySuperloopyPluginRoot(cwd) {
-  // Identify a Superloopy checkout by package identity alone, never by the files that
-  // doctor is meant to test. A real checkout with a broken/wrong-name plugin.json, or
-  // with .codex-plugin or src/cli.js deleted, still gets diagnosed so pluginManifest and
-  // cli checks can surface the failure; an unrelated Codex plugin project (different
-  // package name) falls back to CLI_ROOT instead of collecting Superloopy false failures.
-  return readPackageName(cwd) === "superloopy";
+  // Identify a Superloopy checkout by any stable signal, never by a single file that
+  // doctor itself tests. Keying on one marker (package.json name, the plugin manifest,
+  // or a given file's existence) means a break in that marker silently falls back to
+  // CLI_ROOT and hides the very failure doctor should surface. With any-of, a checkout
+  // is only skipped when every signal is simultaneously broken -- a genuinely
+  // unidentifiable directory -- while an unrelated Codex plugin (no Superloopy identity
+  // and no signature files) still falls back instead of collecting false failures.
+  return jsonNameIs(join(cwd, "package.json"), "superloopy")
+    || jsonNameIs(join(cwd, ".codex-plugin", "plugin.json"), "superloopy")
+    || hasSuperloopySignature(cwd);
 }
 
-function readPackageName(cwd) {
+function jsonNameIs(path, expected) {
   try {
-    return JSON.parse(readFileSync(join(cwd, "package.json"), "utf8")).name;
+    return JSON.parse(readFileSync(path, "utf8")).name === expected;
   } catch {
-    return null;
+    return false;
   }
+}
+
+function hasSuperloopySignature(cwd) {
+  return existsSync(join(cwd, "src", "cli.js"))
+    && existsSync(join(cwd, "src", "doctor.js"))
+    && existsSync(join(cwd, "skills", "superloopy-loop", "SKILL.md"));
 }
 
 async function runLoop(subcommand, argv, stdout, cwd) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hasFlag, parseJson, readFlag, readStdin } from "./args.js";
@@ -124,13 +124,11 @@ function resolveDoctorRoot(cwd, argv) {
 }
 
 function isLikelySuperloopyPluginRoot(cwd) {
-  if (!existsSync(join(cwd, ".codex-plugin")) || !existsSync(join(cwd, "src", "cli.js"))) {
-    return false;
-  }
-  // Identify Superloopy by package identity, not the .codex-plugin manifest: a real
-  // checkout with a broken/wrong-name plugin.json still gets diagnosed (so its
-  // pluginManifest check can fail), while an unrelated Codex plugin project falls
-  // back to CLI_ROOT instead of collecting Superloopy-specific false failures.
+  // Identify a Superloopy checkout by package identity alone, never by the files that
+  // doctor is meant to test. A real checkout with a broken/wrong-name plugin.json, or
+  // with .codex-plugin or src/cli.js deleted, still gets diagnosed so pluginManifest and
+  // cli checks can surface the failure; an unrelated Codex plugin project (different
+  // package name) falls back to CLI_ROOT instead of collecting Superloopy false failures.
   return readPackageName(cwd) === "superloopy";
 }
 

--- a/src/doctor-skills.js
+++ b/src/doctor-skills.js
@@ -32,6 +32,7 @@ export async function checkSkills(cwd) {
       .map((name) => `skills/${name}/SKILL.md`)
   );
   const invalid = [];
+  const unreadable = [];
 
   for (const name of skills) {
     const path = join(skillsDir, name, "SKILL.md");
@@ -39,13 +40,22 @@ export async function checkSkills(cwd) {
       missing.add(`skills/${name}/SKILL.md`);
       continue;
     }
-    const declaredName = readSkillName(await readFile(path, "utf8"));
-    if (declaredName !== name) invalid.push(name);
+    let content;
+    try {
+      content = await readFile(path, "utf8");
+    } catch (error) {
+      // A corrupt cache can have SKILL.md as a directory or otherwise unreadable;
+      // report it as a structured skill problem rather than aborting the whole report.
+      unreadable.push(`skills/${name}/SKILL.md (${errorText(error)})`);
+      continue;
+    }
+    if (readSkillName(content) !== name) invalid.push(name);
   }
 
   const problems = [];
   if (readError !== null) problems.push(`Unable to read skills directory: ${readError}.`);
   if (missing.size > 0) problems.push(`Missing skill files: ${[...missing].sort().join(", ")}.`);
+  if (unreadable.length > 0) problems.push(`Unreadable skill files: ${unreadable.sort().join(", ")}.`);
   if (invalid.length > 0) problems.push(`Invalid skill frontmatter: ${invalid.sort().join(", ")}.`);
   if (problems.length > 0) {
     return { ok: false, skills, requiredSkills: REQUIRED_SKILLS, message: problems.join(" ") };

--- a/src/doctor-skills.js
+++ b/src/doctor-skills.js
@@ -1,0 +1,72 @@
+import { existsSync, readdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const REQUIRED_SKILLS = [
+  "humanize-korean",
+  "superloopy-clone",
+  "superloopy-doctor",
+  "superloopy-frontend",
+  "superloopy-loop",
+  "superloopy-research"
+];
+
+export async function checkSkills(cwd) {
+  const skillsDir = join(cwd, "skills");
+  let readError = null;
+  let entries = [];
+  if (existsSync(skillsDir)) {
+    try {
+      entries = readdirSync(skillsDir, { withFileTypes: true });
+    } catch (error) {
+      readError = errorText(error);
+    }
+  }
+  const skills = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+  const missing = new Set(
+    REQUIRED_SKILLS
+      .filter((name) => !skills.includes(name))
+      .map((name) => `skills/${name}/SKILL.md`)
+  );
+  const invalid = [];
+
+  for (const name of skills) {
+    const path = join(skillsDir, name, "SKILL.md");
+    if (!existsSync(path)) {
+      missing.add(`skills/${name}/SKILL.md`);
+      continue;
+    }
+    const declaredName = readSkillName(await readFile(path, "utf8"));
+    if (declaredName !== name) invalid.push(name);
+  }
+
+  const problems = [];
+  if (readError !== null) problems.push(`Unable to read skills directory: ${readError}.`);
+  if (missing.size > 0) problems.push(`Missing skill files: ${[...missing].sort().join(", ")}.`);
+  if (invalid.length > 0) problems.push(`Invalid skill frontmatter: ${invalid.sort().join(", ")}.`);
+  if (problems.length > 0) {
+    return { ok: false, skills, requiredSkills: REQUIRED_SKILLS, message: problems.join(" ") };
+  }
+  return { ok: true, skills, requiredSkills: REQUIRED_SKILLS };
+}
+
+function readSkillName(content) {
+  const lines = normalizeLineEndings(content).split("\n");
+  if (lines[0] !== "---") return null;
+  for (let index = 1; index < lines.length && lines[index] !== "---"; index += 1) {
+    const match = /^name:\s*"?([^"]+)"?\s*$/u.exec(lines[index]);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function normalizeLineEndings(content) {
+  return content.replace(/\r\n?/gu, "\n");
+}
+
+function errorText(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -6,6 +6,7 @@ import { checkDesignAudit } from "./design-audit.js";
 import { checkFileAudit } from "./file-audit.js";
 import { checkComparisonSimilarity } from "./comparison-similarity.js";
 import { SUPERLOOPY_AGENT_NAMES } from "./agents.js";
+import { checkSkills } from "./doctor-skills.js";
 import { checkClaudeModelPolicy, checkModelPolicy } from "./model-policy.js";
 import { checkInterop } from "./interop.js";
 import { checkWrapper } from "./wrapper-check.js";
@@ -55,6 +56,7 @@ export async function runDoctor(cwd, options = {}) {
   const checks = { pluginManifest, hooks, skills, cli, dependencies, runtimeBoundary, fileAudit, gateNotes, designAudit, comparisonSimilarity, reviewability, dispatchCoherence, claudeHostWiring, modelPolicy, claudeModelPolicy, hostContract: checkHostContract(), interop: checkInterop(options), wrapper: checkWrapper(options) };
   return {
     ok: Object.values(checks).every((check) => check.ok),
+    root: cwd,
     checks
   };
 }
@@ -116,23 +118,6 @@ async function checkHooks(cwd, hooks) {
   if (missing.length > 0) return fail(`Missing hook files: ${missing.join(", ")}.`);
   if (invalid.length > 0) return fail(`Invalid hook files: ${invalid.join(", ")}.`);
   return { ok: true, count: hooks.length };
-}
-
-async function checkSkills(cwd) {
-  const skills = ["superloopy-loop", "superloopy-doctor"];
-  const missing = [], invalid = [];
-  for (const name of skills) {
-    const path = join(cwd, "skills", name, "SKILL.md");
-    if (!existsSync(path)) missing.push(`skills/${name}/SKILL.md`);
-    else if (!new RegExp(`^---\\nname: ${name}$`, "m").test(normalizeLineEndings(await readFile(path, "utf8")))) invalid.push(name);
-  }
-  if (missing.length > 0) return fail(`Missing skill files: ${missing.join(", ")}.`);
-  if (invalid.length > 0) return fail(`Invalid skill frontmatter: ${invalid.join(", ")}.`);
-  return { ok: true, skills };
-}
-
-function normalizeLineEndings(content) {
-  return content.replace(/\r\n?/gu, "\n");
 }
 
 function checkCli(cwd) {

--- a/test/doctor-review-feedback.test.js
+++ b/test/doctor-review-feedback.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+function runCli(args, options = {}) {
+  return spawnSync(process.execPath, [join(process.cwd(), "src/cli.js"), ...args], {
+    cwd: options.cwd ?? process.cwd(),
+    encoding: "utf8",
+    timeout: 10_000
+  });
+}
+
+async function tempRepoCopy() {
+  const repo = await mkdtemp(join(tmpdir(), "superloopy-doctor-review-"));
+  const result = spawnSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 0, result.stderr);
+  for (const file of result.stdout.split("\n").filter(Boolean)) {
+    const source = join(process.cwd(), file);
+    if (!existsSync(source)) continue;
+    const target = join(repo, file);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, await readFile(source));
+  }
+  spawnSync("git", ["init"], { cwd: repo, encoding: "utf8" });
+  return repo;
+}
+
+test("doctor CLI reports a broken checkout manifest instead of silently falling back", async () => {
+  const repo = await tempRepoCopy();
+  await writeFile(
+    join(repo, ".codex-plugin", "plugin.json"),
+    JSON.stringify({ name: "not-superloopy", skills: "./skills/", hooks: [] }, null, 2),
+    "utf8"
+  );
+
+  const result = runCli(["doctor", "--json"], { cwd: repo });
+
+  assert.equal(result.status, 1, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.root, repo);
+  assert.equal(parsed.checks.pluginManifest.ok, false);
+  assert.match(parsed.checks.pluginManifest.message, /Plugin name must be superloopy/);
+});
+
+test("doctor CLI returns a structured skills failure when skills is not a directory", async () => {
+  const repo = await tempRepoCopy();
+  await rm(join(repo, "skills"), { recursive: true, force: true });
+  await writeFile(join(repo, "skills"), "not a directory\n", "utf8");
+
+  const result = runCli(["doctor", "--root", repo, "--json"]);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.equal(result.stderr, "");
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.checks.skills.ok, false);
+  assert.match(parsed.checks.skills.message, /Unable to read skills directory/);
+  assert.match(parsed.checks.skills.message, /Missing skill files: .*superloopy-doctor/);
+});

--- a/test/doctor-review-feedback.test.js
+++ b/test/doctor-review-feedback.test.js
@@ -66,6 +66,20 @@ test("doctor CLI returns a structured skills failure when skills is not a direct
   assert.match(parsed.checks.skills.message, /Missing skill files: .*superloopy-doctor/);
 });
 
+test("doctor CLI diagnoses a checkout whose .codex-plugin was deleted", async () => {
+  const repo = await tempRepoCopy();
+  await rm(join(repo, ".codex-plugin"), { recursive: true, force: true });
+
+  const result = runCli(["doctor", "--json"], { cwd: repo });
+
+  assert.equal(result.status, 1, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  // Identified as Superloopy by package.json name, so the deletion is reported
+  // instead of silently falling back to the installed CLI root.
+  assert.equal(parsed.root, repo);
+  assert.equal(parsed.checks.pluginManifest.ok, false);
+});
+
 test("doctor CLI falls back to CLI root from an unrelated Codex plugin project", async () => {
   const project = await mkdtemp(join(tmpdir(), "superloopy-doctor-foreign-"));
   await mkdir(join(project, ".codex-plugin"), { recursive: true });

--- a/test/doctor-review-feedback.test.js
+++ b/test/doctor-review-feedback.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -15,7 +15,9 @@ function runCli(args, options = {}) {
 }
 
 async function tempRepoCopy() {
-  const repo = await mkdtemp(join(tmpdir(), "superloopy-doctor-review-"));
+  // Canonicalize so the path matches process.cwd() inside the spawned CLI:
+  // on macOS tmpdir() lives under the /var -> /private/var symlink.
+  const repo = realpathSync(await mkdtemp(join(tmpdir(), "superloopy-doctor-review-")));
   const result = spawnSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], {
     cwd: process.cwd(),
     encoding: "utf8"

--- a/test/doctor-review-feedback.test.js
+++ b/test/doctor-review-feedback.test.js
@@ -80,6 +80,20 @@ test("doctor CLI diagnoses a checkout whose .codex-plugin was deleted", async ()
   assert.equal(parsed.checks.pluginManifest.ok, false);
 });
 
+test("doctor CLI diagnoses a checkout with a malformed package.json", async () => {
+  const repo = await tempRepoCopy();
+  await writeFile(join(repo, "package.json"), "{ not valid json\n", "utf8");
+
+  const result = runCli(["doctor", "--json"], { cwd: repo });
+
+  assert.equal(result.status, 1, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  // package.json is broken, but the plugin manifest / signature still identify the
+  // checkout, so its own dependency check is reported instead of a green CLI_ROOT.
+  assert.equal(parsed.root, repo);
+  assert.equal(parsed.checks.dependencies.ok, false);
+});
+
 test("doctor CLI falls back to CLI root from an unrelated Codex plugin project", async () => {
   const project = await mkdtemp(join(tmpdir(), "superloopy-doctor-foreign-"));
   await mkdir(join(project, ".codex-plugin"), { recursive: true });

--- a/test/doctor-review-feedback.test.js
+++ b/test/doctor-review-feedback.test.js
@@ -65,3 +65,43 @@ test("doctor CLI returns a structured skills failure when skills is not a direct
   assert.match(parsed.checks.skills.message, /Unable to read skills directory/);
   assert.match(parsed.checks.skills.message, /Missing skill files: .*superloopy-doctor/);
 });
+
+test("doctor CLI falls back to CLI root from an unrelated Codex plugin project", async () => {
+  const project = await mkdtemp(join(tmpdir(), "superloopy-doctor-foreign-"));
+  await mkdir(join(project, ".codex-plugin"), { recursive: true });
+  await writeFile(
+    join(project, ".codex-plugin", "plugin.json"),
+    JSON.stringify({ name: "some-other-plugin" }, null, 2),
+    "utf8"
+  );
+  await mkdir(join(project, "src"), { recursive: true });
+  await writeFile(join(project, "src", "cli.js"), "// unrelated plugin\n", "utf8");
+  await writeFile(
+    join(project, "package.json"),
+    JSON.stringify({ name: "some-other-plugin" }, null, 2),
+    "utf8"
+  );
+
+  const result = runCli(["doctor", "--json"], { cwd: project });
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  // Not Superloopy by package identity -> diagnose the installed CLI root, not this project.
+  assert.equal(parsed.root, process.cwd());
+  assert.equal(parsed.ok, true);
+});
+
+test("doctor CLI returns a structured skills failure when a SKILL.md is unreadable", async () => {
+  const repo = await tempRepoCopy();
+  const skillFile = join(repo, "skills", "superloopy-doctor", "SKILL.md");
+  await rm(skillFile, { force: true });
+  await mkdir(skillFile, { recursive: true });
+
+  const result = runCli(["doctor", "--root", repo, "--json"]);
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.equal(result.stderr, "");
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.checks.skills.ok, false);
+  assert.match(parsed.checks.skills.message, /Unreadable skill files: .*superloopy-doctor/);
+});

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -11,6 +11,8 @@ import { formatDoctor, runDoctor } from "../src/doctor.js";
 import { checkWrapper, evaluateWrapperCurrency } from "../src/wrapper-check.js";
 import { parseBinShimCliPath } from "../src/agents.js";
 
+const EXPECTED_SKILLS = ["humanize-korean", "superloopy-clone", "superloopy-doctor", "superloopy-frontend", "superloopy-loop", "superloopy-research"];
+
 function runCli(args, options = {}) {
   return spawnSync(process.execPath, [join(process.cwd(), "src/cli.js"), ...args], {
     cwd: options.cwd ?? process.cwd(),
@@ -75,6 +77,7 @@ test("doctor --json reports Superloopy packaging, audit, and reviewability check
   assert.equal(result.status, 0, result.stderr);
   const parsed = JSON.parse(result.stdout);
   assert.equal(parsed.ok, true);
+  assert.equal(parsed.root, process.cwd());
   assert.deepEqual(Object.keys(parsed.checks), [
     "pluginManifest",
     "hooks",
@@ -98,7 +101,8 @@ test("doctor --json reports Superloopy packaging, audit, and reviewability check
   assert.equal(parsed.checks.pluginManifest.ok, true);
   assert.equal(parsed.checks.hooks.ok, true);
   assert.equal(parsed.checks.skills.ok, true);
-  assert.deepEqual(parsed.checks.skills.skills, ["superloopy-loop", "superloopy-doctor"]);
+  assert.deepEqual(parsed.checks.skills.skills, EXPECTED_SKILLS);
+  assert.deepEqual(parsed.checks.skills.requiredSkills, EXPECTED_SKILLS);
   assert.equal(parsed.checks.cli.ok, true);
   assert.equal(parsed.checks.dependencies.ok, true);
   assert.equal(parsed.checks.dependencies.count, 0);
@@ -281,6 +285,28 @@ test("checkWrapper stays silent when no wrapper is on PATH", () => {
   assert.equal(result.found, false);
 });
 
+test("doctor CLI falls back to the CLI root outside a Superloopy checkout", async () => {
+  const project = await mkdtemp(join(tmpdir(), "superloopy-doctor-project-"));
+  const result = runCli(["doctor", "--json"], { cwd: project });
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.root, process.cwd());
+  assert.equal(parsed.checks.pluginManifest.ok, true);
+});
+
+test("doctor CLI accepts an explicit diagnostic root", async () => {
+  const repo = await tempRepoCopy();
+  const result = runCli(["doctor", "--root", repo, "--json"], { cwd: tmpdir() });
+
+  assert.equal(result.status, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.root, repo);
+  assert.deepEqual(parsed.checks.skills.skills, EXPECTED_SKILLS);
+});
+
 test("doctor model policy fails when bundled agent defaults drift", async () => {
   const repo = await tempRepoCopy();
   const agentPath = join(repo, ".codex", "agents", "nami.toml");
@@ -346,6 +372,17 @@ test("doctor skill check requires the bundled doctor skill", async () => {
   assert.equal(result.ok, false);
   assert.equal(result.checks.skills.ok, false);
   assert.match(result.checks.skills.message, /superloopy-doctor/);
+});
+
+test("doctor skill check requires every bundled skill", async () => {
+  const repo = await tempRepoCopy();
+  await rm(join(repo, "skills", "superloopy-frontend"), { recursive: true, force: true });
+
+  const result = await runDoctor(repo);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.checks.skills.ok, false);
+  assert.match(result.checks.skills.message, /superloopy-frontend/);
 });
 
 test("doctor text reports whether comparison scanning was skipped", () => {


### PR DESCRIPTION
## Summary
- Make `superloopy doctor` resolve the checked plugin root explicitly: current directory when it is a Superloopy checkout, otherwise the CLI install root, with `--root` / `--plugin-root` for explicit targeting.
- Include the checked `root` in doctor JSON output so diagnostics show what was actually inspected.
- Move skill validation into `src/doctor-skills.js` and require all bundled skills, not just `superloopy-loop` and `superloopy-doctor`.
- Update doctor/loop docs and Superloopy audit inventories for the new behavior.

## Why
Running `superloopy doctor --json` from an arbitrary project directory could report a wall of false failures such as missing `.codex-plugin/plugin.json`, even when the installed plugin and wrapper were healthy. That makes install/debug sessions look broken for the wrong reason. Also, the `skills` check only covered two skills while the package currently ships six, so missing bundled skills could slip past doctor.

## Validation
- `node --test test/doctor.test.js`
- `node --test test/docs.test.js`
- `node src/cli.js doctor --json`
- `node D:\alone\program_alone\superloopy-pr\src\cli.js doctor --json` from another project cwd
- `npm test`