### PR TITLE
Fix Superloopy evidence gates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "superloopy",
       "source": "./",
       "description": "Strict evidence loop harness: repo-local loop state, success criteria, append-only ledgers, evidence-gated completion, plus skills (loop, research, frontend, clone) and a read-only/worker crew. Works on Claude Code and Codex from one repo.",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Lightweight loop harness with strict evidence gates — Claude Code edition.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Lightweight loop harness with strict evidence gates.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/docs/superloopy-file-audit.md
+++ b/docs/superloopy-file-audit.md
@@ -276,7 +276,7 @@ Superloopy is its own lightweight loop harness: one small CLI, repo-local `.supe
 
 ## Weight Notes
 
-- Current largest source file: `src/hooks.js`, below the reviewability cap (500 lines). Keep new checks in helper modules (for example `src/interop.js` holds `checkInterop` and `src/doctor-skills.js` holds bundled skill checks) rather than growing orchestrators past the cap.
+- Current largest source file: `src/doctor.js`, below the reviewability cap (500 lines). Keep new checks in helper modules (for example `src/interop.js` holds `checkInterop` and `src/doctor-skills.js` holds bundled skill checks) rather than growing orchestrators past the cap.
 - No package dependencies are added; `package.json` stays dependency-free and `superloopy doctor --json` checks that boundary.
 - Marketplace update checks are advisory and self-update only runs for a future npx-local snapshot; current marketplace and checkout installs keep their documented update commands.
 - Runtime state is ignored under `.superloopy/`; `superloopy doctor --json` verifies runtime samples are ignored and not tracked.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superloopy",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superloopy",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "bin": {
         "superloopy": "src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A lightweight loop harness for Codex and Claude Code with strict evidence gates.",
   "type": "module",
   "bin": {

--- a/skills/humanize-korean/scripts/audit-humanize-output.mjs
+++ b/skills/humanize-korean/scripts/audit-humanize-output.mjs
@@ -51,44 +51,79 @@ if (!args.source || !args.final || !args.report) {
   fail("Usage: audit-humanize-output.mjs --source SOURCE --final FINAL --report REPORT");
 }
 
-const source = await readFile(args.source, "utf8");
-const final = await readFile(args.final, "utf8");
-const sourceRatio = koreanRatio(source);
-const finalRatio = koreanRatio(final);
-if (sourceRatio < 0.2) fail("Korean source text required");
-
-const protectedTokens = collectProtectedTokens(source);
-const missing = [...protectedTokens].filter((token) => !final.includes(token));
-const before = countPatterns(source);
-const after = countPatterns(final);
-const changeRate = levenshtein(source, final) / Math.max(source.length, 1);
-const problems = [];
-if (missing.length > 0) problems.push("Protected tokens changed");
-if (finalRatio < 0.2) problems.push("Final text is not Korean enough");
-if (changeRate > 0.5) problems.push("Change rate exceeds 50%");
-if (requiredS1Count(before) > 0 && requiredS1Count(after) >= requiredS1Count(before)) {
-  problems.push("S1 AI-tell count not reduced");
+let report;
+try {
+  report = await audit(args);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  await writeFailureReport(args.report, message);
+  fail(message);
 }
 
-const warnings = changeRate > 0.3 && changeRate <= 0.5 ? ["Change rate exceeds 30%"] : [];
-const report = {
-  ok: problems.length === 0,
-  grade: grade({ after, changeRate, missing, problems }),
-  sourceChars: source.length,
-  finalChars: final.length,
-  changeRate: Number(changeRate.toFixed(4)),
-  koreanRatio: {
-    source: Number(sourceRatio.toFixed(4)),
-    final: Number(finalRatio.toFixed(4))
-  },
-  protectedTokens: { total: protectedTokens.size, missing },
-  patterns: { before, after },
-  warnings,
-  problems
-};
-
 await writeFile(args.report, `${JSON.stringify(report, null, 2)}\n`);
-if (!report.ok) fail(problems.join("; "));
+if (!report.ok) fail(report.problems.join("; "));
+
+async function audit(args) {
+  const source = await readInputFile("source", args.source);
+  const final = await readInputFile("final", args.final);
+  const sourceRatio = koreanRatio(source);
+  const finalRatio = koreanRatio(final);
+  const protectedTokens = collectProtectedTokens(source);
+  const missing = [...protectedTokens].filter((token) => !final.includes(token));
+  const before = countPatterns(source);
+  const after = countPatterns(final);
+  const changeRate = levenshtein(source, final) / Math.max(source.length, 1);
+  const problems = [];
+  if (sourceRatio < 0.2) problems.push("Korean source text required");
+  if (missing.length > 0) problems.push("Protected tokens changed");
+  if (finalRatio < 0.2) problems.push("Final text is not Korean enough");
+  if (changeRate > 0.5) problems.push("Change rate exceeds 50%");
+  if (requiredS1Count(before) > 0 && requiredS1Count(after) >= requiredS1Count(before)) {
+    problems.push("S1 AI-tell count not reduced");
+  }
+
+  const warnings = changeRate > 0.3 && changeRate <= 0.5 ? ["Change rate exceeds 30%"] : [];
+  return {
+    ok: problems.length === 0,
+    grade: grade({ after, changeRate, missing, problems }),
+    sourceChars: source.length,
+    finalChars: final.length,
+    changeRate: Number(changeRate.toFixed(4)),
+    koreanRatio: {
+      source: Number(sourceRatio.toFixed(4)),
+      final: Number(finalRatio.toFixed(4))
+    },
+    protectedTokens: { total: protectedTokens.size, missing },
+    patterns: { before, after },
+    warnings,
+    problems
+  };
+}
+
+async function readInputFile(label, path) {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    const reason = error instanceof Error && "code" in error ? error.code : error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read ${label} file: ${path} (${reason})`);
+  }
+}
+
+async function writeFailureReport(path, message) {
+  const report = {
+    ok: false,
+    grade: "D",
+    sourceChars: 0,
+    finalChars: 0,
+    changeRate: 0,
+    koreanRatio: { source: 0, final: 0 },
+    protectedTokens: { total: 0, missing: [] },
+    patterns: { before: {}, after: {} },
+    warnings: [],
+    problems: [message]
+  };
+  await writeFile(path, `${JSON.stringify(report, null, 2)}\n`);
+}
 
 function parseArgs(values) {
   const parsed = {};

--- a/skills/superloopy-frontend/scripts/visual-diff.mjs
+++ b/skills/superloopy-frontend/scripts/visual-diff.mjs
@@ -17,6 +17,8 @@ import { deflateSync, inflateSync } from "node:zlib";
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const GRID_SIZE = 8;
+const MAX_PIXELS = 25_000_000;
+const MAX_INFLATED_BYTES = 128 * 1024 * 1024;
 
 const CRC_TABLE = (() => {
   const table = new Int32Array(256);
@@ -78,9 +80,17 @@ export function decodePng(buffer) {
   if (interlace !== 0) throw new Error("Interlaced PNG is unsupported.");
   const channels = CHANNELS_BY_COLOR_TYPE[colorType];
   if (channels === undefined) throw new Error(`Unsupported PNG color type ${colorType}.`);
+  if (width <= 0 || height <= 0) throw new Error("PNG dimensions must be positive.");
+  const pixelsCount = width * height;
+  const inflatedBytes = height * (width * channels + 1);
+  if (!Number.isSafeInteger(pixelsCount) || pixelsCount > MAX_PIXELS || inflatedBytes > MAX_INFLATED_BYTES) {
+    throw new Error(`PNG dimensions exceed safe decode limits (${width}x${height}).`);
+  }
 
   const raw = inflateSync(Buffer.concat(idat));
   const stride = width * channels;
+  if (raw.length < inflatedBytes) throw new Error("PNG image data is truncated.");
+  if (raw.length > MAX_INFLATED_BYTES) throw new Error("PNG image data exceeds safe decode limits.");
   const pixels = Buffer.alloc(height * stride);
   let prevRow = Buffer.alloc(stride);
   let src = 0;

--- a/src/args.js
+++ b/src/args.js
@@ -1,8 +1,8 @@
-export function readFlag(argv, name) {
+export function readFlag(argv, name, options = {}) {
   const index = argv.indexOf(name);
   if (index === -1) return undefined;
   const value = argv[index + 1];
-  if (value === undefined || value.startsWith("--")) {
+  if (value === undefined || (!options.allowLeadingDashValue && value.startsWith("--"))) {
     throw new Error(`Missing ${name}.`);
   }
   return value;

--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -1,4 +1,5 @@
-import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { constants, existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { mkdir, open } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { validateAuditSection } from "./audit-verdict.js";
 import { isMatrixQualityGate, validateMatrixQualityGate } from "./matrix-gate.js";
@@ -89,6 +90,29 @@ export function resolveEvidenceOutputPath(cwd, artifactPath, scope) {
     absolutePath: resolved,
     relativePath: repoRelativePath(`${evidenceRelativeDir(scope)}/${rel}`)
   };
+}
+
+export async function writeEvidenceOutputFile(artifact, content, options = "utf8") {
+  await mkdir(dirname(artifact.absolutePath), { recursive: true });
+  const noFollow = constants.O_NOFOLLOW ?? 0;
+  let handle;
+  try {
+    handle = await open(
+      artifact.absolutePath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow,
+      0o666
+    );
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ELOOP") {
+      throw new Error(`Evidence artifact write target must not be a symlink: ${artifact.relativePath}`);
+    }
+    throw error;
+  }
+  try {
+    await handle.writeFile(content, options);
+  } finally {
+    await handle.close();
+  }
 }
 
 function lstatNoFollow(path) {

--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -1,5 +1,5 @@
-import { constants, existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
-import { mkdir, open } from "node:fs/promises";
+import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { mkdir, open, rename, rm } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { validateAuditSection } from "./audit-verdict.js";
 import { isMatrixQualityGate, validateMatrixQualityGate } from "./matrix-gate.js";
@@ -88,30 +88,43 @@ export function resolveEvidenceOutputPath(cwd, artifactPath, scope) {
   }
   return {
     absolutePath: resolved,
+    rootPath: root,
     relativePath: repoRelativePath(`${evidenceRelativeDir(scope)}/${rel}`)
   };
 }
 
 export async function writeEvidenceOutputFile(artifact, content, options = "utf8") {
-  await mkdir(dirname(artifact.absolutePath), { recursive: true });
-  const noFollow = constants.O_NOFOLLOW ?? 0;
+  const dir = dirname(artifact.absolutePath);
+  await mkdir(dir, { recursive: true });
+  rejectOutputTargetForWrite(artifact);
+  const tmpPath = join(dir, `.${basename(artifact.absolutePath)}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`);
   let handle;
   try {
-    handle = await open(
-      artifact.absolutePath,
-      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow,
-      0o666
-    );
-  } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "ELOOP") {
-      throw new Error(`Evidence artifact write target must not be a symlink: ${artifact.relativePath}`);
-    }
-    throw error;
-  }
-  try {
+    handle = await open(tmpPath, "wx", 0o666);
     await handle.writeFile(content, options);
-  } finally {
     await handle.close();
+    handle = null;
+    rejectOutputTargetForWrite(artifact);
+    await rename(tmpPath, artifact.absolutePath);
+  } catch (error) {
+    await rm(tmpPath, { force: true }).catch(() => {});
+    throw error;
+  } finally {
+    if (handle) await handle.close();
+  }
+}
+
+function rejectOutputTargetForWrite(artifact) {
+  if (artifact.rootPath) {
+    rejectSymlinkInExistingPath(artifact.rootPath, artifact.absolutePath, artifact.relativePath);
+  }
+  const targetStat = lstatNoFollow(artifact.absolutePath);
+  if (!targetStat) return;
+  if (targetStat.isSymbolicLink()) {
+    throw new Error(`Evidence artifact write target must not be a symlink: ${artifact.relativePath}`);
+  }
+  if (!targetStat.isFile()) {
+    throw new Error(`Evidence artifact is not a file: ${artifact.relativePath}`);
   }
 }
 

--- a/src/audit-hooks.js
+++ b/src/audit-hooks.js
@@ -14,20 +14,12 @@ import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { resolveEvidenceArtifact } from "./artifacts.js";
 import { auditMaxFails, auditOneCriterion, recordAuditFailure } from "./audit.js";
-import { transcriptTailHasMarker } from "./continuation.js";
+import { CONTEXT_PRESSURE_MARKERS, transcriptTailHasMarker } from "./continuation.js";
 import { auditReceiptFromPayload, normalizeAgentType, subagentTranscriptPath } from "./receipt.js";
 import { validateAuditVerdict, verifyVerdictAgainstState } from "./audit-verdict.js";
 import { appendLedger, auditStatePath, evidenceRelativeDir, goalsPath, nowIso, scopeFromSessionId, withFileLock, writeJsonAtomic } from "./store.js";
 
 const MAX_AUDIT_ATTEMPTS = 3;
-// Generic context-pressure markers (kept in sync with the hook runtime); on a
-// compaction the handler pauses without burning an attempt.
-const CONTEXT_PRESSURE_MARKERS = [
-  "context compacted", "context_length_exceeded", "skill descriptions were shortened",
-  "context_too_large", "codex ran out of room in the model's context window",
-  "your input exceeds the context window", "long threads and multiple compactions"
-];
-
 export async function runAuditorStopHook(payload) {
   if (payload === null || typeof payload !== "object") return "";
   if (payload.hook_event_name !== "SubagentStop") return "";

--- a/src/audit.js
+++ b/src/audit.js
@@ -13,10 +13,10 @@
 // is skipped: no re-run, no LLM.
 
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { readFlag } from "./args.js";
-import { resolveEvidenceArtifact, resolveEvidenceOutputPath } from "./artifacts.js";
+import { resolveEvidenceArtifact, resolveEvidenceOutputPath, writeEvidenceOutputFile } from "./artifacts.js";
 import { runCaptured } from "./capture.js";
 import { evidenceLoop } from "./loop.js";
 import { isTrustedCommand } from "./plan-trust.js";
@@ -70,7 +70,7 @@ export async function auditLoop(cwd, argv) {
     const gap = entry.rerunStatus === "untrusted-command"
       ? `Audit refused to re-run ${entry.criterion}: its plan command was never executed on this machine (goals.json may have arrived with the repo). Re-prove it with \`superloopy loop prove\`, or approve the plan's commands once with \`superloopy loop trust\`.`
       : `Audit could not re-validate the recorded proof for ${entry.criterion}; re-prove it.`;
-    await writeFile(note.absolutePath, `${gap}\n`, "utf8");
+    await writeEvidenceOutputFile(note, `${gap}\n`);
     await recordAuditFailure(cwd, scope, entry.criterion, gap, note.relativePath, entry.failCount, maxFails);
   }
 

--- a/src/auto-update-state.js
+++ b/src/auto-update-state.js
@@ -23,12 +23,13 @@ export function resolveLockPath(env, statePath) {
 
 export async function acquireLock(lockPath, now, staleMs = DEFAULT_LOCK_STALE_MS) {
   await mkdir(dirname(lockPath), { recursive: true });
+  const token = `${process.pid} ${now}`;
   try {
     const handle = await open(lockPath, "wx");
-    await handle.writeFile(`${now}\n`);
+    await handle.writeFile(`${token}\n`);
     await handle.close();
     return {
-      release: () => rm(lockPath, { force: true })
+      release: () => releaseIfOwned(lockPath, token)
     };
   } catch (error) {
     if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
@@ -43,7 +44,10 @@ export async function readState(statePath) {
     const parsed = JSON.parse(raw);
     return typeof parsed === "object" && parsed !== null ? parsed : {};
   } catch (error) {
-    if (error instanceof Error) return {};
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return {};
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid Superloopy auto-update state JSON: ${statePath}`);
+    }
     throw error;
   }
 }
@@ -66,13 +70,59 @@ export async function appendUpdateLog(env, now, event, details = {}) {
 
 async function removeStaleLock(lockPath, now, staleMs) {
   if (staleMs <= 0) return false;
+  let content;
+  try {
+    content = await readFile(lockPath, "utf8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
+    throw error;
+  }
+  const token = parseLockToken(content);
+  if (token !== null) {
+    try {
+      process.kill(token.pid, 0);
+      return false;
+    } catch (error) {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "ESRCH") return false;
+      return await removeIfContentMatches(lockPath, content);
+    }
+  }
   try {
     const lockStat = await stat(lockPath);
     if (now - lockStat.mtimeMs < staleMs) return false;
+    return await removeIfContentMatches(lockPath, content);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
+    throw error;
+  }
+}
+
+function parseLockToken(content) {
+  const parts = content.trim().split(/\s+/u);
+  if (parts.length < 2) return null;
+  const pid = Number.parseInt(parts[0], 10);
+  const createdAt = Number.parseInt(parts[1], 10);
+  if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(createdAt)) return null;
+  return { pid, createdAt };
+}
+
+async function removeIfContentMatches(lockPath, content) {
+  try {
+    if (await readFile(lockPath, "utf8") !== content) return false;
     await rm(lockPath, { force: true });
     return true;
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") return true;
     throw error;
+  }
+}
+
+async function releaseIfOwned(lockPath, token) {
+  try {
+    if ((await readFile(lockPath, "utf8")).trim() === token) {
+      await rm(lockPath, { force: true });
+    }
+  } catch {
+    // best-effort release
   }
 }

--- a/src/capture.js
+++ b/src/capture.js
@@ -1,12 +1,14 @@
-import { spawnSync } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { readFlag } from "./args.js";
-import { resolveEvidenceOutputPath } from "./artifacts.js";
+import { resolveEvidenceOutputPath, writeEvidenceOutputFile } from "./artifacts.js";
 import { evidenceLoop } from "./loop.js";
 import { recordTrustedCommand } from "./plan-trust.js";
 import { resolveSpawnInvocation } from "./spawn-command.js";
 import { ensureSuperloopyDirs, evidenceRelativeDir, nowIso, scopeFromSessionId } from "./store.js";
+
+const MAX_CAPTURE_STREAM_BYTES = 10 * 1024 * 1024;
 
 // Shared deterministic re-run core: spawn a command, derive pass/fail from the
 // exit status exactly as capture does, and write a transcript artifact. Reused
@@ -19,11 +21,7 @@ export async function runCaptured(cwd, command, artifact) {
   // (CVE-2024-27980 hardening) -> ENOENT and every command-backed proof fails.
   // Route the known shim set through cmd.exe exactly like auto-update does.
   const invocation = resolveSpawnInvocation(command[0], command.slice(1));
-  const commandResult = spawnSync(invocation.command, invocation.args, {
-    cwd,
-    encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024
-  });
+  const commandResult = await runCommand(invocation, cwd);
   const finishedAt = nowIso();
   const status = commandResult.status === 0 && commandResult.signal === null && commandResult.error === undefined ? "pass" : "fail";
   const capture = {
@@ -36,7 +34,7 @@ export async function runCaptured(cwd, command, artifact) {
     finishedAt
   };
   if (commandResult.error) capture.error = commandResult.error.message;
-  await writeFile(artifact.absolutePath, renderCaptureTranscript(cwd, capture, commandResult), "utf8");
+  await writeEvidenceOutputFile(artifact, renderCaptureTranscript(cwd, capture, commandResult));
   return capture;
 }
 
@@ -100,9 +98,71 @@ function renderCaptureTranscript(cwd, capture, commandResult) {
     "",
     "[stdout]",
     commandResult.stdout ?? "",
+    truncatedLine("stdout", commandResult.stdoutTruncatedBytes),
     "[stderr]",
-    commandResult.stderr ?? ""
+    commandResult.stderr ?? "",
+    truncatedLine("stderr", commandResult.stderrTruncatedBytes)
   ].filter((line) => line !== "").join("\n");
+}
+
+function truncatedLine(stream, truncatedBytes) {
+  return truncatedBytes > 0
+    ? `[${stream} truncated after ${MAX_CAPTURE_STREAM_BYTES} bytes; ${truncatedBytes} additional bytes omitted]`
+    : "";
+}
+
+function runCommand(invocation, cwd) {
+  return new Promise((resolve) => {
+    const stdout = captureStreamBuffer();
+    const stderr = captureStreamBuffer();
+    let error;
+    const child = spawn(invocation.command, invocation.args, {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", (caught) => {
+      error = caught;
+    });
+    child.on("close", (status, signal) => {
+      resolve({
+        status,
+        signal,
+        error,
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+        stdoutTruncatedBytes: stdout.truncatedBytes(),
+        stderrTruncatedBytes: stderr.truncatedBytes()
+      });
+    });
+  });
+}
+
+function captureStreamBuffer() {
+  const chunks = [];
+  let kept = 0;
+  let truncated = 0;
+  return {
+    push(chunk) {
+      const buffer = Buffer.from(chunk);
+      if (kept < MAX_CAPTURE_STREAM_BYTES) {
+        const available = MAX_CAPTURE_STREAM_BYTES - kept;
+        const take = Math.min(available, buffer.length);
+        if (take > 0) chunks.push(buffer.subarray(0, take));
+        kept += take;
+        truncated += buffer.length - take;
+      } else {
+        truncated += buffer.length;
+      }
+    },
+    text() {
+      return Buffer.concat(chunks).toString("utf8");
+    },
+    truncatedBytes() {
+      return truncated;
+    }
+  };
 }
 
 function readScope(argv) {

--- a/src/check.js
+++ b/src/check.js
@@ -1,6 +1,6 @@
 import { readFlag } from "./args.js";
 import { resolveEvidenceArtifact } from "./artifacts.js";
-import { buildGuide, formatGuideResult } from "./guide.js";
+import { buildGuide, captureCommand, evidenceCommand, formatGuideResult } from "./guide.js";
 import { traceLoop } from "./trace.js";
 import { readPlan, scopeFromSessionId } from "./store.js";
 
@@ -36,7 +36,7 @@ export function formatCheckResult(result) {
   const lines = ["superloopy check: blocked", evidenceSummaryLine(result)];
   lines.push(...warningLines(result.warnings));
   if (result.unresolvedCriteria.length > 0) {
-    lines.push("", "Unresolved criteria:", ...result.unresolvedCriteria.map((item) => `- ${item.ref} ${item.status} -> \`${item.suggestedArtifact}\` ${item.scenario}`));
+    lines.push("", "Unresolved criteria:", ...result.unresolvedCriteria.map((item) => `- ${item.ref} ${item.status} -> \`${item.suggestedArtifact}\` - ${item.scenario}`));
   }
   if (result.invalidArtifacts.length > 0) {
     lines.push("", "Invalid artifacts:", ...result.invalidArtifacts.map((item) => `- ${item.ref} ${item.artifact}: ${item.error}`));
@@ -130,23 +130,4 @@ function repairStepLines(item) {
     `   capture: \`${item.primaryCommand}\``,
     `   evidence: \`${item.alternativeCommand}\``
   ];
-}
-
-function command(subcommand, sessionId, args) {
-  const parts = ["superloopy", "loop", subcommand];
-  if (sessionId) parts.push("--session-id", sessionId);
-  return [...parts, ...args.map((arg) => quoteCommandArg(arg))].join(" ");
-}
-
-function captureCommand(sessionId, goalId, criterionId) {
-  return `${command("capture", sessionId, ["--goal-id", goalId, "--criterion-id", criterionId, "--notes", "<summary>"])} -- <validation-command>`;
-}
-
-function evidenceCommand(sessionId, goalId, criterionId, artifact) {
-  return command("evidence", sessionId, ["--goal-id", goalId, "--criterion-id", criterionId, "--status", "pass", "--artifact", artifact, "--notes", "<summary>", "--json"]);
-}
-
-function quoteCommandArg(value) {
-  if (/^[A-Za-z0-9._/@:=+-]+$/u.test(value)) return value;
-  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
 }

--- a/src/comparison-similarity.js
+++ b/src/comparison-similarity.js
@@ -94,13 +94,19 @@ function readGitHead(path, name) {
     timeout: 10_000
   });
   if (result.status !== 0) {
-    throw new Error(result.stderr.trim() || `Unable to read ${name} checkout HEAD.`);
+    throw new Error(readSpawnFailure(result, `Unable to read ${name} checkout HEAD.`));
   }
   const head = result.stdout.trim();
   if (!/^[0-9a-f]{40}$/u.test(head)) {
     throw new Error(`Unable to parse ${name} checkout HEAD.`);
   }
   return head;
+}
+
+function readSpawnFailure(result, fallback) {
+  const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+  const error = result.error instanceof Error ? result.error.message : "";
+  return stderr || error || fallback;
 }
 
 async function buildComparisonBlockIndex(sources) {

--- a/src/continuation.js
+++ b/src/continuation.js
@@ -30,6 +30,11 @@ export const QUOTA_LIMIT_MARKERS = [
   "session limit reached",
   "too many requests"
 ];
+export const CONTEXT_PRESSURE_MARKERS = [
+  "context compacted", "context_length_exceeded", "skill descriptions were shortened",
+  "context_too_large", "codex ran out of room in the model's context window",
+  "your input exceeds the context window", "long threads and multiple compactions"
+];
 
 export function quotaLimitMarkers(env = {}) {
   const extra = String(env.SUPERLOOPY_QUOTA_MARKERS ?? "")

--- a/src/guide.js
+++ b/src/guide.js
@@ -313,7 +313,7 @@ function flowStep(id, label, status, commandText) {
   return { id, label, status, command: commandText };
 }
 
-function flowStepLine(step) {
+export function flowStepLine(step) {
   return `- [${step.status}] ${step.label}: \`${step.command}\``;
 }
 
@@ -330,7 +330,7 @@ function buildProofPlan(unresolvedCriteria, sessionId) {
   }));
 }
 
-function proofPlanLine(item) {
+export function proofPlanLine(item) {
   return `- ${item.ref} ${item.status} capture \`${item.captureCommand}\` or evidence \`${item.evidenceCommand}\``;
 }
 
@@ -338,36 +338,36 @@ function proofTargetLine(target) {
   return `Proof target: ${target.ref} ${target.status} -> \`${target.artifact}\``;
 }
 
-function recordedEvidenceLine(item) {
+export function recordedEvidenceLine(item) {
   const artifact = item.artifact === null ? "no artifact" : `\`${item.artifact}\``;
   const capturedAt = item.capturedAt === null ? "" : ` at ${item.capturedAt}`;
   const notes = item.notes === undefined ? "" : ` - notes: ${item.notes}`;
-  return `- ${item.ref} ${item.status}${capturedAt} -> ${artifact} ${item.scenario}${notes}`;
+  return `- ${item.ref} ${item.status}${capturedAt} -> ${artifact} - ${item.scenario}${notes}`;
 }
 
-function unresolvedCriterionLine(criterion) {
-  return `- ${criterion.ref} ${criterion.status} -> \`${criterion.suggestedArtifact}\` ${criterion.scenario}`;
+export function unresolvedCriterionLine(criterion) {
+  return `- ${criterion.ref} ${criterion.status} -> \`${criterion.suggestedArtifact}\` - ${criterion.scenario}`;
 }
 
-function command(subcommand, sessionId, args) {
+export function command(subcommand, sessionId, args) {
   const parts = ["superloopy", "loop", subcommand];
   if (sessionId) parts.push("--session-id", sessionId);
   return [...parts, ...args.map((arg) => quoteCommandArg(arg))].join(" ");
 }
 
-function captureCommand(sessionId, goalId, criterionId) {
+export function captureCommand(sessionId, goalId, criterionId) {
   return `${command("capture", sessionId, ["--goal-id", goalId, "--criterion-id", criterionId, "--notes", "<summary>"])} -- <validation-command>`;
 }
 
-function evidenceCommand(sessionId, goalId, criterionId, artifact) {
+export function evidenceCommand(sessionId, goalId, criterionId, artifact) {
   return command("evidence", sessionId, ["--goal-id", goalId, "--criterion-id", criterionId, "--status", "pass", "--artifact", artifact, "--notes", "<summary>", "--json"]);
 }
 
-function proveCommand(sessionId) {
+export function proveCommand(sessionId) {
   return `${command("prove", sessionId, [])} -- <validation-command>`;
 }
 
-function quoteCommandArg(value) {
+export function quoteCommandArg(value) {
   if (/^[A-Za-z0-9._/@:=+-]+$/u.test(value)) return value;
   return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -3,8 +3,8 @@ import { bootstrapHasUserSignal, bootstrapSuperloopy, formatBootstrapHookContext
 import { runAutoUpdateCheck } from "./auto-update.js";
 import { parseJson } from "./args.js";
 import { resolveEvidenceArtifact } from "./artifacts.js";
-import { buildGuide } from "./guide.js";
-import { decideContinuation, transcriptTailHasMarker } from "./continuation.js";
+import { buildGuide, flowStepLine, proofPlanLine, recordedEvidenceLine } from "./guide.js";
+import { CONTEXT_PRESSURE_MARKERS, decideContinuation, transcriptTailHasMarker } from "./continuation.js";
 import { normalizeAgentType, receiptFromPayload, subagentTranscriptPath } from "./receipt.js";
 import { hasEngineerTrigger, hasFrontendTrigger, hasKoreanWritingTrigger, renderFrontendTriggerContext, renderKoreanWritingTriggerContext, runEngineerTriggerHook } from "./engineer.js";
 import { applySteering, statusLoop } from "./loop.js";
@@ -17,11 +17,6 @@ const EVIDENCE_RECEIPT_AGENT_TYPES = new Set(["franky", "zoro", "usopp", "jinbe"
 // An artifact up to this size must carry non-whitespace content to satisfy the receipt gate;
 // only larger artifacts (assumed non-trivial) skip the read. Closes the blank-placeholder hole.
 const MAX_BLANK_CHECK_BYTES = 1_000_000;
-const CONTEXT_PRESSURE_MARKERS = [
-  "context compacted", "context_length_exceeded", "skill descriptions were shortened",
-  "context_too_large", "codex ran out of room in the model's context window",
-  "your input exceeds the context window", "long threads and multiple compactions"
-];
 const LOOSE_TRIGGER_PATTERN = /(^|[^A-Za-z0-9_-])(\$?(?:loopywork|lpy))(?=$|[^A-Za-z0-9_-])/iu;
 const LOOSE_TRIGGER_GLOBAL_PATTERN = /(^|[^A-Za-z0-9_-])(\$?(?:loopywork|lpy))(?=$|[^A-Za-z0-9_-])/giu;
 const PROTECTED_STEERING_KEYS = new Set([
@@ -392,7 +387,7 @@ function renderProofPlan(guide) {
   if (!Array.isArray(guide.proofPlan) || guide.proofPlan.length === 0) return [];
   return [
     "Proof plan:",
-    ...guide.proofPlan.map((item) => `- ${item.ref} ${item.status} capture \`${item.captureCommand}\` or evidence \`${item.evidenceCommand}\``)
+    ...guide.proofPlan.map(proofPlanLine)
   ];
 }
 
@@ -400,7 +395,7 @@ function renderFlow(guide) {
   if (!Array.isArray(guide.flow) || guide.flow.length === 0) return [];
   return [
     "Flow checklist:",
-    ...guide.flow.map((step) => `- [${step.status}] ${step.label}: \`${step.command}\``)
+    ...guide.flow.map(flowStepLine)
   ];
 }
 
@@ -408,12 +403,7 @@ function renderRecordedEvidence(guide) {
   if (!Array.isArray(guide.recordedEvidence) || guide.recordedEvidence.length === 0) return [];
   return [
     "Recorded evidence:",
-    ...guide.recordedEvidence.map((item) => {
-      const artifact = item.artifact === null ? "no artifact" : `\`${item.artifact}\``;
-      const capturedAt = item.capturedAt === null ? "" : ` at ${item.capturedAt}`;
-      const notes = item.notes === undefined ? "" : ` - notes: ${item.notes}`;
-      return `- ${item.ref} ${item.status}${capturedAt} -> ${artifact}${notes}`;
-    })
+    ...guide.recordedEvidence.map(recordedEvidenceLine)
   ];
 }
 

--- a/src/loop.js
+++ b/src/loop.js
@@ -156,19 +156,21 @@ export async function checkpointLoop(cwd, argv) {
   const goalId = required(argv, "--goal-id");
   const status = readCheckpointStatus(required(argv, "--status"));
   const evidence = required(argv, "--evidence");
+  const preflight = status === "complete"
+    ? await preflightCheckpointCompletion(cwd, argv, scope, goalId)
+    : { qualityGate: null };
   return await withFileLock(goalsPath(cwd, scope), async () => {
     const plan = await readPlan(cwd, scope);
     const goal = findGoal(plan, goalId);
     const now = nowIso();
-    let qualityGate = null;
+    let qualityGate = preflight.qualityGate;
     if (status === "complete") {
       requireEssentialCriteriaPass(goal);
       if (isFinalGoal(plan, goal)) {
         requireAllPlanCriteriaPass(plan);
-        qualityGate = await readQualityGate(cwd, required(argv, "--quality-gate"), scope);
-        // The deterministic spine must actually gate completion: re-derive and verify
-        // every cited audit verdict before authorizing aggregate completion.
-        await enforceAuditProvenance(cwd, scope, qualityGate.audit);
+        if (qualityGate === null) {
+          throw new Error("Plan changed during checkpoint validation; retry the final checkpoint.");
+        }
         plan.aggregateCompletion = { status: "complete", completedAt: now, evidence, qualityGate };
       }
       goal.status = "complete";
@@ -191,6 +193,20 @@ export async function checkpointLoop(cwd, argv) {
     }, scope);
     return { ok: true, goal, plan, summary: summarizePlan(plan), guide: buildGuide(plan, { cwd, scope }) };
   });
+}
+
+async function preflightCheckpointCompletion(cwd, argv, scope, goalId) {
+  const plan = await readPlan(cwd, scope);
+  const goal = findGoal(plan, goalId);
+  requireEssentialCriteriaPass(goal);
+  if (!isFinalGoal(plan, goal)) return { qualityGate: null };
+  requireAllPlanCriteriaPass(plan);
+  const qualityGate = await readQualityGate(cwd, required(argv, "--quality-gate"), scope);
+  // Run audit re-derivation before taking the goals lock. The audit path takes
+  // audit-state first and may then record evidence, so holding goals here would
+  // invert that lock order and deadlock concurrent audit acceptance.
+  await enforceAuditProvenance(cwd, scope, qualityGate.audit);
+  return { qualityGate };
 }
 
 export async function reviewLoop(cwd, argv) {

--- a/src/loop.js
+++ b/src/loop.js
@@ -40,7 +40,7 @@ export { guideLoop, helpText };
 
 export async function createLoop(cwd, argv) {
   const scope = readScope(argv);
-  const brief = readFlag(argv, "--brief")?.trim();
+  const brief = readFlag(argv, "--brief", { allowLeadingDashValue: true })?.trim();
   if (!brief) throw new Error("Missing --brief.");
   const mode = readMode(readFlag(argv, "--mode") ?? "light");
   const force = argv.includes("--force");
@@ -79,30 +79,32 @@ export async function statusLoop(cwd, argv = []) {
 
 export async function nextLoop(cwd, argv = []) {
   const scope = readScope(argv);
-  const plan = await readPlan(cwd, scope);
-  const result = (fields) => ({
-    ok: true,
-    plan,
-    summary: summarizePlan(plan),
-    guide: buildGuide(plan, { cwd, scope }),
-    ...fields
+  return await withFileLock(goalsPath(cwd, scope), async () => {
+    const plan = await readPlan(cwd, scope);
+    const result = (fields) => ({
+      ok: true,
+      plan,
+      summary: summarizePlan(plan),
+      guide: buildGuide(plan, { cwd, scope }),
+      ...fields
+    });
+    if (plan.aggregateCompletion?.status === "complete") {
+      return result({ done: true });
+    }
+    const existing = plan.goals.find((goal) => goal.status === "in_progress");
+    if (existing) return result({ resumed: true, goal: existing });
+    const next = plan.goals.find((goal) => goal.status === "pending");
+    if (!next) return result({ done: true });
+    const now = nowIso();
+    next.status = "in_progress";
+    next.startedAt = now;
+    next.updatedAt = now;
+    next.attempt += 1;
+    plan.updatedAt = now;
+    await writePlan(cwd, plan, scope);
+    await appendLedger(cwd, { at: now, kind: "goal_started", goalId: next.id, attempt: next.attempt }, scope);
+    return result({ resumed: false, goal: next });
   });
-  if (plan.aggregateCompletion?.status === "complete") {
-    return result({ done: true });
-  }
-  const existing = plan.goals.find((goal) => goal.status === "in_progress");
-  if (existing) return result({ resumed: true, goal: existing });
-  const next = plan.goals.find((goal) => goal.status === "pending");
-  if (!next) return result({ done: true });
-  const now = nowIso();
-  next.status = "in_progress";
-  next.startedAt = now;
-  next.updatedAt = now;
-  next.attempt += 1;
-  plan.updatedAt = now;
-  await writePlan(cwd, plan, scope);
-  await appendLedger(cwd, { at: now, kind: "goal_started", goalId: next.id, attempt: next.attempt }, scope);
-  return result({ resumed: false, goal: next });
 }
 
 export async function evidenceLoop(cwd, argv) {
@@ -154,39 +156,41 @@ export async function checkpointLoop(cwd, argv) {
   const goalId = required(argv, "--goal-id");
   const status = readCheckpointStatus(required(argv, "--status"));
   const evidence = required(argv, "--evidence");
-  const plan = await readPlan(cwd, scope);
-  const goal = findGoal(plan, goalId);
-  const now = nowIso();
-  let qualityGate = null;
-  if (status === "complete") {
-    requireEssentialCriteriaPass(goal);
-    if (isFinalGoal(plan, goal)) {
-      requireAllPlanCriteriaPass(plan);
-      qualityGate = await readQualityGate(cwd, required(argv, "--quality-gate"), scope);
-      // The deterministic spine must actually gate completion: re-derive and verify
-      // every cited audit verdict before authorizing aggregate completion.
-      await enforceAuditProvenance(cwd, scope, qualityGate.audit);
-      plan.aggregateCompletion = { status: "complete", completedAt: now, evidence, qualityGate };
+  return await withFileLock(goalsPath(cwd, scope), async () => {
+    const plan = await readPlan(cwd, scope);
+    const goal = findGoal(plan, goalId);
+    const now = nowIso();
+    let qualityGate = null;
+    if (status === "complete") {
+      requireEssentialCriteriaPass(goal);
+      if (isFinalGoal(plan, goal)) {
+        requireAllPlanCriteriaPass(plan);
+        qualityGate = await readQualityGate(cwd, required(argv, "--quality-gate"), scope);
+        // The deterministic spine must actually gate completion: re-derive and verify
+        // every cited audit verdict before authorizing aggregate completion.
+        await enforceAuditProvenance(cwd, scope, qualityGate.audit);
+        plan.aggregateCompletion = { status: "complete", completedAt: now, evidence, qualityGate };
+      }
+      goal.status = "complete";
+      goal.completedAt = now;
+    } else {
+      goal.status = status === "failed" ? "failed" : "blocked";
+      goal.failureReason = evidence;
     }
-    goal.status = "complete";
-    goal.completedAt = now;
-  } else {
-    goal.status = status === "failed" ? "failed" : "blocked";
-    goal.failureReason = evidence;
-  }
-  goal.evidence = evidence;
-  goal.updatedAt = now;
-  plan.updatedAt = now;
-  await writePlan(cwd, plan, scope);
-  await appendLedger(cwd, {
-    at: now,
-    kind: plan.aggregateCompletion?.completedAt === now ? "aggregate_completed" : `goal_${goal.status}`,
-    goalId,
-    status: goal.status,
-    evidence,
-    qualityGate
-  }, scope);
-  return { ok: true, goal, plan, summary: summarizePlan(plan), guide: buildGuide(plan, { cwd, scope }) };
+    goal.evidence = evidence;
+    goal.updatedAt = now;
+    plan.updatedAt = now;
+    await writePlan(cwd, plan, scope);
+    await appendLedger(cwd, {
+      at: now,
+      kind: plan.aggregateCompletion?.completedAt === now ? "aggregate_completed" : `goal_${goal.status}`,
+      goalId,
+      status: goal.status,
+      evidence,
+      qualityGate
+    }, scope);
+    return { ok: true, goal, plan, summary: summarizePlan(plan), guide: buildGuide(plan, { cwd, scope }) };
+  });
 }
 
 export async function reviewLoop(cwd, argv) {
@@ -245,90 +249,96 @@ async function annotateOnly(cwd, directive, scope) {
 }
 
 async function addGoalFromSteering(cwd, directive, scope) {
-  const plan = await readPlan(cwd, scope);
-  if (plan.aggregateCompletion?.status === "complete") {
-    throw new Error("Cannot add a goal after aggregate completion.");
-  }
-  const now = nowIso();
-  const goal = makeGoal({
-    title: directive.title.length > 72 ? `${directive.title.slice(0, 69).trimEnd()}...` : directive.title,
-    objective: directive.objective
-  }, nextGoalIndex(plan), plan.mode, now);
-  plan.goals.push(goal);
-  plan.updatedAt = now;
-  await writePlan(cwd, plan, scope);
-  await appendLedger(cwd, {
-    at: now,
-    kind: "goal_added",
-    goalId: goal.id,
-    title: goal.title,
-    rationale: directive.rationale
-  }, scope);
-  return { ok: true, kind: "goal_added", goal, plan, summary: summarizePlan(plan) };
+  return await withFileLock(goalsPath(cwd, scope), async () => {
+    const plan = await readPlan(cwd, scope);
+    if (plan.aggregateCompletion?.status === "complete") {
+      throw new Error("Cannot add a goal after aggregate completion.");
+    }
+    const now = nowIso();
+    const goal = makeGoal({
+      title: directive.title.length > 72 ? `${directive.title.slice(0, 69).trimEnd()}...` : directive.title,
+      objective: directive.objective
+    }, nextGoalIndex(plan), plan.mode, now);
+    plan.goals.push(goal);
+    plan.updatedAt = now;
+    await writePlan(cwd, plan, scope);
+    await appendLedger(cwd, {
+      at: now,
+      kind: "goal_added",
+      goalId: goal.id,
+      title: goal.title,
+      rationale: directive.rationale
+    }, scope);
+    return { ok: true, kind: "goal_added", goal, plan, summary: summarizePlan(plan) };
+  });
 }
 
 async function reviseCriterionFromSteering(cwd, directive, scope) {
-  const plan = await readPlan(cwd, scope);
-  if (plan.aggregateCompletion?.status === "complete") {
-    throw new Error("Cannot revise criteria after aggregate completion.");
-  }
-  const goal = findGoal(plan, directive.goalId);
-  const criterion = findCriterion(goal, directive.criterionId);
-  if (goal.status === "complete") throw new Error(`Cannot revise completed goal: ${goal.id}`);
-  if (criterion.status === "pass") throw new Error(`Cannot revise passed criterion: ${goal.id}/${criterion.id}`);
-  const now = nowIso();
-  const before = {
-    scenario: criterion.scenario,
-    status: criterion.status,
-    artifact: criterion.artifact
-  };
-  criterion.scenario = directive.scenario;
-  criterion.status = "pending";
-  criterion.artifact = null;
-  criterion.capturedAt = null;
-  delete criterion.notes;
-  goal.updatedAt = now;
-  plan.updatedAt = now;
-  await writePlan(cwd, plan, scope);
-  await appendLedger(cwd, {
-    at: now,
-    kind: "criterion_revised",
-    goalId: goal.id,
-    criterionId: criterion.id,
-    before,
-    after: { scenario: criterion.scenario },
-    rationale: directive.rationale
-  }, scope);
-  return { ok: true, kind: "criterion_revised", goal, criterion, plan, summary: summarizePlan(plan) };
+  return await withFileLock(goalsPath(cwd, scope), async () => {
+    const plan = await readPlan(cwd, scope);
+    if (plan.aggregateCompletion?.status === "complete") {
+      throw new Error("Cannot revise criteria after aggregate completion.");
+    }
+    const goal = findGoal(plan, directive.goalId);
+    const criterion = findCriterion(goal, directive.criterionId);
+    if (goal.status === "complete") throw new Error(`Cannot revise completed goal: ${goal.id}`);
+    if (criterion.status === "pass") throw new Error(`Cannot revise passed criterion: ${goal.id}/${criterion.id}`);
+    const now = nowIso();
+    const before = {
+      scenario: criterion.scenario,
+      status: criterion.status,
+      artifact: criterion.artifact
+    };
+    criterion.scenario = directive.scenario;
+    criterion.status = "pending";
+    criterion.artifact = null;
+    criterion.capturedAt = null;
+    delete criterion.notes;
+    goal.updatedAt = now;
+    plan.updatedAt = now;
+    await writePlan(cwd, plan, scope);
+    await appendLedger(cwd, {
+      at: now,
+      kind: "criterion_revised",
+      goalId: goal.id,
+      criterionId: criterion.id,
+      before,
+      after: { scenario: criterion.scenario },
+      rationale: directive.rationale
+    }, scope);
+    return { ok: true, kind: "criterion_revised", goal, criterion, plan, summary: summarizePlan(plan) };
+  });
 }
 
 async function reorderPendingFromSteering(cwd, directive, scope) {
-  const plan = await readPlan(cwd, scope);
-  if (plan.aggregateCompletion?.status === "complete") {
-    throw new Error("Cannot reorder goals after aggregate completion.");
-  }
-  const requested = directive.goalIds.map((goalId) => findGoal(plan, goalId));
-  const nonPending = requested.filter((goal) => goal.status !== "pending");
-  if (nonPending.length > 0) {
-    throw new Error(`Cannot reorder non-pending goals: ${nonPending.map((goal) => goal.id).join(", ")}`);
-  }
-  const now = nowIso();
-  const requestedIds = new Set(directive.goalIds);
-  const locked = plan.goals.filter((goal) => goal.status !== "pending");
-  const remainingPending = plan.goals.filter((goal) => goal.status === "pending" && !requestedIds.has(goal.id));
-  const orderedPending = directive.goalIds.map((goalId) => findGoal(plan, goalId));
-  const before = plan.goals.map((goal) => goal.id);
-  plan.goals = [...locked, ...remainingPending, ...orderedPending];
-  plan.updatedAt = now;
-  await writePlan(cwd, plan, scope);
-  await appendLedger(cwd, {
-    at: now,
-    kind: "goals_reordered",
-    before,
-    after: plan.goals.map((goal) => goal.id),
-    rationale: directive.rationale
-  }, scope);
-  return { ok: true, kind: "goals_reordered", plan, summary: summarizePlan(plan) };
+  return await withFileLock(goalsPath(cwd, scope), async () => {
+    const plan = await readPlan(cwd, scope);
+    if (plan.aggregateCompletion?.status === "complete") {
+      throw new Error("Cannot reorder goals after aggregate completion.");
+    }
+    const requested = directive.goalIds.map((goalId) => findGoal(plan, goalId));
+    const nonPending = requested.filter((goal) => goal.status !== "pending");
+    if (nonPending.length > 0) {
+      throw new Error(`Cannot reorder non-pending goals: ${nonPending.map((goal) => goal.id).join(", ")}`);
+    }
+    const now = nowIso();
+    const requestedIds = new Set(directive.goalIds);
+    const locked = plan.goals.filter((goal) => goal.status !== "pending");
+    const remainingPending = plan.goals.filter((goal) => goal.status === "pending" && !requestedIds.has(goal.id));
+    const orderedPending = directive.goalIds.map((goalId) => findGoal(plan, goalId));
+    const before = plan.goals.map((goal) => goal.id);
+    plan.goals = [...locked, ...remainingPending, ...orderedPending];
+    plan.updatedAt = now;
+    await writePlan(cwd, plan, scope);
+    await appendLedger(cwd, {
+      at: now,
+      kind: "goals_reordered",
+      before,
+      after: plan.goals.map((goal) => goal.id),
+      rationale: directive.rationale
+    }, scope);
+    return { ok: true, kind: "goals_reordered", plan, summary: summarizePlan(plan) };
+  });
 }
 
 function readMode(value) {

--- a/src/matrix-gate.js
+++ b/src/matrix-gate.js
@@ -1,4 +1,5 @@
 import { validateAuditSection } from "./audit-verdict.js";
+import { artifactPath, emptyBlockers, fail, isRecord, literal, passedVerdict, referencedArtifacts, section, stringArray, textField } from "./review-gate.js";
 
 const REQUIRED_SECTIONS = ["architectReview", "executorQa", "iteration"];
 const TERMINAL_MULTIPLEXER_SURFACE = ["t", "m", "u", "x"].join("");
@@ -155,50 +156,8 @@ function parseContractCoverage(value, surfaceById, adversarialById, artifactById
   });
 }
 
-function artifactPath(value, field, resolveArtifactPath) {
-  return resolveArtifactPath(textField(value, field));
-}
-
-function section(value, field) {
-  if (!isRecord(value)) fail(`${field} must be an object.`);
-  return value;
-}
-
-function textField(value, field) {
-  if (typeof value !== "string" || value.trim().length === 0) fail(`${field} must be a non-empty string.`);
-  const trimmed = value.trim();
-  if (/^(todo|tbd|placeholder)$/iu.test(trimmed)) fail(`${field} must not be placeholder text.`);
-  return trimmed;
-}
-
-function literal(value, expected, field) {
-  if (value !== expected) fail(`${field} must be ${expected}.`);
-  return expected;
-}
-
-function emptyBlockers(value, field) {
-  if (!Array.isArray(value)) fail(`${field} must be an array.`);
-  if (value.length !== 0) fail(`${field} must be empty.`);
-  return [];
-}
-
-function stringArray(value, field) {
-  if (!Array.isArray(value) || !value.every((item) => typeof item === "string" && item.trim().length > 0)) {
-    fail(`${field} must be a string array.`);
-  }
-  return value.map((item) => item.trim());
-}
-
 function optionalStringArray(value, field) {
   return value === undefined ? [] : stringArray(value, field);
-}
-
-function referencedArtifacts(value, field, byId) {
-  return stringArray(value, field).map((id) => {
-    const artifact = byId.get(id);
-    if (artifact === undefined) fail(`${field} references unknown artifact ${id}.`);
-    return artifact;
-  });
 }
 
 function optionalText(value) {
@@ -241,11 +200,6 @@ function artifactKind(value, field) {
   fail(`${field} must be a supported executor QA artifact kind.`);
 }
 
-function passedVerdict(value, field) {
-  if (value === "not_applicable") fail(`${field} must not be not_applicable.`);
-  return literal(value, "passed", field);
-}
-
 function coveredStatus(value, field) {
   const status = textField(value, field);
   if (["covered", "passed", "verified"].includes(status)) return status;
@@ -265,12 +219,4 @@ function requireSurfaceProof(family, artifacts, field) {
   if (family === "native" && !kinds.some((kind) => ["screenshot", "image", "pty-capture", "app-automation-transcript"].includes(kind))) {
     fail(`${field} for native surfaces must reference screenshot, PTY, or app automation artifacts.`);
   }
-}
-
-function isRecord(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function fail(message) {
-  throw new Error(message);
 }

--- a/src/report.js
+++ b/src/report.js
@@ -1,9 +1,9 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { readFlag } from "./args.js";
-import { resolveEvidenceOutputPath } from "./artifacts.js";
-import { buildGuide } from "./guide.js";
-import { traceLoop } from "./trace.js";
+import { resolveEvidenceOutputPath, writeEvidenceOutputFile } from "./artifacts.js";
+import { buildGuide, proofPlanLine, recordedEvidenceLine, unresolvedCriterionLine } from "./guide.js";
+import { evidenceArtifactLine, timelineLine, traceLoop, warningLine } from "./trace.js";
 import { appendLedger, ensureSuperloopyDirs, evidenceRelativeDir, nowIso, readPlan, scopeFromSessionId } from "./store.js";
 
 const DEFAULT_REPORT_NAME = "report.md";
@@ -15,7 +15,7 @@ export async function reportLoop(cwd, argv = []) {
   const trace = await traceLoop(cwd, argv);
   await ensureSuperloopyDirs(cwd, scope);
   await mkdir(dirname(artifact.absolutePath), { recursive: true });
-  await writeFile(artifact.absolutePath, renderEvidenceReport(trace), "utf8");
+  await writeEvidenceOutputFile(artifact, renderEvidenceReport(trace));
   const now = nowIso();
   await appendLedger(cwd, {
     at: now,
@@ -65,7 +65,7 @@ export function renderEvidenceReport(trace) {
 
 function renderWarnings(warnings) {
   if (!Array.isArray(warnings) || warnings.length === 0) return ["- none"];
-  return warnings.map((item) => `- ${item.kind}: ${item.message}`);
+  return warnings.map(warningLine);
 }
 
 function renderEvidenceSummary(summary) {
@@ -91,43 +91,25 @@ function renderNextAction(guide) {
 
 function renderProofPlan(proofPlan) {
   if (proofPlan.length === 0) return ["- none"];
-  return proofPlan.map((item) => `- ${item.ref} ${item.status} capture \`${item.captureCommand}\` or evidence \`${item.evidenceCommand}\``);
+  return proofPlan.map(proofPlanLine);
 }
 
 function renderRecordedEvidence(recordedEvidence) {
   if (recordedEvidence.length === 0) return ["- none"];
-  return recordedEvidence.map((item) => {
-    const artifact = item.artifact === null ? "no artifact" : `\`${item.artifact}\``;
-    const capturedAt = item.capturedAt === null ? "" : ` at ${item.capturedAt}`;
-    const notes = item.notes === undefined ? "" : ` - notes: ${item.notes}`;
-    return `- ${item.ref} ${item.status}${capturedAt} -> ${artifact} - ${item.scenario}${notes}`;
-  });
+  return recordedEvidence.map(recordedEvidenceLine);
 }
 
 function renderArtifacts(artifacts) {
   if (artifacts.length === 0) return ["- none"];
-  return artifacts.map((item) => {
-    const capturedAt = item.capturedAt === null ? "" : ` at ${item.capturedAt}`;
-    const notes = item.notes === undefined ? "" : ` - notes: ${item.notes}`;
-    return `- ${item.ref} ${item.status}${capturedAt} \`${item.artifact}\` - ${item.scenario}${notes}`;
-  });
+  return artifacts.map(evidenceArtifactLine);
 }
 
 function renderMissingCriteria(criteria) {
   if (criteria.length === 0) return ["- none"];
-  return criteria.map((item) => `- ${item.ref} ${item.status} -> \`${item.suggestedArtifact}\` - ${item.scenario}`);
+  return criteria.map(unresolvedCriterionLine);
 }
 
 function renderTimeline(timeline) {
   if (timeline.length === 0) return ["- none"];
-  return timeline.map((item) => {
-    const parts = [`${item.index}.`];
-    if (item.at) parts.push(item.at);
-    parts.push(item.kind);
-    if (item.ref) parts.push(item.ref);
-    if (item.status) parts.push(item.status);
-    if (item.artifact) parts.push(`\`${item.artifact}\``);
-    if (item.notes !== null && item.notes !== undefined) parts.push(`notes: ${item.notes}`);
-    return `- ${parts.join(" ")}`;
-  });
+  return timeline.map(timelineLine);
 }

--- a/src/review-gate.js
+++ b/src/review-gate.js
@@ -118,16 +118,16 @@ function validateCriteriaCoverage(coverage) {
   };
 }
 
-function artifactPath(value, field, resolveArtifactPath) {
+export function artifactPath(value, field, resolveArtifactPath) {
   return resolveArtifactPath(textField(value, field));
 }
 
-function section(value, field) {
+export function section(value, field) {
   if (!isRecord(value)) fail(`${field} must be an object.`);
   return value;
 }
 
-function textField(value, field) {
+export function textField(value, field) {
   if (typeof value !== "string" || value.trim().length === 0) fail(`${field} must be a non-empty string.`);
   const trimmed = value.trim();
   if (/^(todo|tbd|placeholder)$/iu.test(trimmed)) fail(`${field} must not be placeholder text.`);
@@ -139,25 +139,25 @@ function numberField(value, field) {
   return value;
 }
 
-function literal(value, expected, field) {
+export function literal(value, expected, field) {
   if (value !== expected) fail(`${field} must be ${expected}.`);
   return expected;
 }
 
-function emptyBlockers(value, field) {
+export function emptyBlockers(value, field) {
   if (!Array.isArray(value)) fail(`${field} must be an array.`);
   if (value.length !== 0) fail(`${field} must be empty.`);
   return [];
 }
 
-function stringArray(value, field) {
+export function stringArray(value, field) {
   if (!Array.isArray(value) || !value.every((item) => typeof item === "string" && item.trim().length > 0)) {
     fail(`${field} must be a string array.`);
   }
   return value.map((item) => item.trim());
 }
 
-function referencedArtifacts(value, field, byId) {
+export function referencedArtifacts(value, field, byId) {
   return stringArray(value, field).map((id) => {
     const artifact = byId.get(id);
     if (artifact === undefined) fail(`${field} references unknown artifact ${id}.`);
@@ -175,7 +175,7 @@ function artifactKind(value, field) {
   fail(`${field} must be a supported artifact kind.`);
 }
 
-function passedVerdict(value, field) {
+export function passedVerdict(value, field) {
   if (value === "not_applicable") fail(`${field} must not be not_applicable.`);
   return literal(value, "passed", field);
 }
@@ -188,10 +188,10 @@ function artifactCompatible(surface, kind) {
   return false;
 }
 
-function isRecord(value) {
+export function isRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function fail(message) {
+export function fail(message) {
   throw new Error(message);
 }

--- a/src/spawn-command.js
+++ b/src/spawn-command.js
@@ -1,4 +1,13 @@
-const WINDOWS_CMD_SHIM_COMMANDS = new Set(["npm", "npx"]);
+const WINDOWS_CMD_SHIM_COMMANDS = new Set([
+  "npm",
+  "npx",
+  "pnpm",
+  "yarn",
+  "vitest",
+  "tsc",
+  "eslint",
+  "playwright"
+]);
 
 export function resolveSpawnInvocation(command, args, platform = process.platform) {
   const invocation = { command, args: Array.from(args) };

--- a/src/store.js
+++ b/src/store.js
@@ -225,14 +225,20 @@ function sleep(ms) {
 }
 
 export async function readPlan(cwd, scope) {
+  let parsed;
   try {
-    return JSON.parse(await readFile(goalsPath(cwd, scope), "utf8"));
+    parsed = JSON.parse(await readFile(goalsPath(cwd, scope), "utf8"));
   } catch (error) {
     if (error && error.code === "ENOENT") {
       throw new Error("No Superloopy plan found. Run `superloopy loop create --brief ...` first.");
     }
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid Superloopy plan JSON in ${goalsRelativePath(scope)}: ${error.message}`);
+    }
     throw error;
   }
+  validatePlanShape(parsed, scope);
+  return parsed;
 }
 
 export async function readLedger(cwd, scope) {
@@ -272,5 +278,22 @@ function parseLedgerLine(line, index) {
     return JSON.parse(line);
   } catch (error) {
     throw new Error(`Invalid Superloopy ledger JSON on line ${index + 1}.`);
+  }
+}
+
+function validatePlanShape(plan, scope) {
+  if (plan === null || typeof plan !== "object" || Array.isArray(plan)) {
+    throw new Error(`Invalid Superloopy plan in ${goalsRelativePath(scope)}: plan must be an object.`);
+  }
+  if (!Array.isArray(plan.goals)) {
+    throw new Error(`Invalid Superloopy plan: goals must be an array in ${goalsRelativePath(scope)}.`);
+  }
+  for (const [goalIndex, goal] of plan.goals.entries()) {
+    if (goal === null || typeof goal !== "object" || Array.isArray(goal)) {
+      throw new Error(`Invalid Superloopy plan: goals[${goalIndex}] must be an object.`);
+    }
+    if (!Array.isArray(goal.criteria)) {
+      throw new Error(`Invalid Superloopy plan: goals[${goalIndex}].criteria must be an array.`);
+    }
   }
 }

--- a/src/trace.js
+++ b/src/trace.js
@@ -1,5 +1,5 @@
 import { readFlag } from "./args.js";
-import { buildGuide, formatGuideResult } from "./guide.js";
+import { buildGuide, formatGuideResult, unresolvedCriterionLine } from "./guide.js";
 import { summarizePlan } from "./plan-summary.js";
 import { evidenceRelativeDir, ledgerRelativePath, readLedger, readPlan, scopeFromSessionId } from "./store.js";
 
@@ -148,33 +148,41 @@ function attemptExhaustionWarnings(timeline) {
 
 function renderArtifacts(artifacts) {
   if (artifacts.length === 0) return ["- none"];
-  return artifacts.map((item) => {
-    const capturedAt = item.capturedAt === null ? "" : ` at ${item.capturedAt}`;
-    const notes = item.notes === undefined ? "" : ` - notes: ${item.notes}`;
-    return `- ${item.ref} ${item.status}${capturedAt} \`${item.artifact}\`${notes}`;
-  });
+  return artifacts.map(evidenceArtifactLine);
 }
 
 function renderMissingCriteria(criteria) {
   if (criteria.length === 0) return ["- none"];
-  return criteria.map((item) => `- ${item.ref} ${item.status} -> \`${item.suggestedArtifact}\` ${item.scenario}`);
+  return criteria.map(unresolvedCriterionLine);
 }
 
 function renderWarnings(warnings) {
   if (!Array.isArray(warnings) || warnings.length === 0) return ["- none"];
-  return warnings.map((item) => `- ${item.kind}: ${item.message}`);
+  return warnings.map(warningLine);
 }
 
 function renderTimeline(timeline) {
   if (timeline.length === 0) return ["- none"];
-  return timeline.map((item) => {
-    const parts = [`${item.index}.`];
-    if (item.at) parts.push(item.at);
-    parts.push(item.kind);
-    if (item.ref) parts.push(item.ref);
-    if (item.status) parts.push(item.status);
-    if (item.artifact) parts.push(`\`${item.artifact}\``);
-    if (item.notes !== null && item.notes !== undefined) parts.push(`notes: ${item.notes}`);
-    return `- ${parts.join(" ")}`;
-  });
+  return timeline.map(timelineLine);
+}
+
+export function evidenceArtifactLine(item) {
+  const capturedAt = item.capturedAt === null ? "" : ` at ${item.capturedAt}`;
+  const notes = item.notes === undefined ? "" : ` - notes: ${item.notes}`;
+  return `- ${item.ref} ${item.status}${capturedAt} \`${item.artifact}\` - ${item.scenario}${notes}`;
+}
+
+export function warningLine(item) {
+  return `- ${item.kind}: ${item.message}`;
+}
+
+export function timelineLine(item) {
+  const parts = [`${item.index}.`];
+  if (item.at) parts.push(item.at);
+  parts.push(item.kind);
+  if (item.ref) parts.push(item.ref);
+  if (item.status) parts.push(item.status);
+  if (item.artifact) parts.push(`\`${item.artifact}\``);
+  if (item.notes !== null && item.notes !== undefined) parts.push(`notes: ${item.notes}`);
+  return `- ${parts.join(" ")}`;
 }

--- a/test/auto-update.test.js
+++ b/test/auto-update.test.js
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import { resolveAutoUpdatePlan, resolveSuperloopyUpdatePlan, runAutoUpdateCheck } from "../src/auto-update.js";
+import { acquireLock, readState } from "../src/auto-update-state.js";
 import { detectInstallFlow } from "../src/install-flow.js";
 import { resolveSpawnInvocation } from "../src/spawn-command.js";
 
@@ -81,15 +82,57 @@ test("Superloopy update plan handles semver and malformed versions", () => {
   assert.equal(resolveSuperloopyUpdatePlan({ currentVersion: "1.0.0", latestVersion: "latest" }).reason, "unknown-latest");
 });
 
-test("spawn invocation uses Windows cmd shims for npm and npx only", () => {
+test("spawn invocation routes common Windows command shims through cmd.exe", () => {
   assert.deepEqual(resolveSpawnInvocation("npx", ["--yes", "superloopy@latest"], "win32"), {
     command: "cmd.exe",
     args: ["/d", "/s", "/c", "npx.cmd", "--yes", "superloopy@latest"]
+  });
+  assert.deepEqual(resolveSpawnInvocation("pnpm", ["test"], "win32"), {
+    command: "cmd.exe",
+    args: ["/d", "/s", "/c", "pnpm.cmd", "test"]
+  });
+  assert.deepEqual(resolveSpawnInvocation("vitest", ["run"], "win32"), {
+    command: "cmd.exe",
+    args: ["/d", "/s", "/c", "vitest.cmd", "run"]
   });
   assert.deepEqual(resolveSpawnInvocation("node", ["src/cli.js"], "win32"), {
     command: "node",
     args: ["src/cli.js"]
   });
+});
+
+test("auto-update state rejects corrupt JSON instead of silently resetting", async () => {
+  const root = await mkdtemp(join(tmpdir(), "superloopy-auto-update-corrupt-"));
+  const statePath = join(root, "state.json");
+  await writeFile(statePath, "{not-json", "utf8");
+
+  await assert.rejects(readState(statePath), /Invalid Superloopy auto-update state JSON/);
+});
+
+test("auto-update lock does not reclaim a stale-looking live holder", async () => {
+  const root = await mkdtemp(join(tmpdir(), "superloopy-auto-update-lock-"));
+  const lockPath = join(root, "state.json.lock");
+  await writeFile(lockPath, `${process.pid} 1\n`, "utf8");
+  const old = new Date(Date.now() - 60_000);
+  await utimes(lockPath, old, old);
+
+  const lock = await acquireLock(lockPath, Date.now(), 1);
+
+  assert.equal(lock, null);
+  assert.equal(await readFile(lockPath, "utf8"), `${process.pid} 1\n`);
+});
+
+test("auto-update lock reclaims stale legacy timestamp-only locks", async () => {
+  const root = await mkdtemp(join(tmpdir(), "superloopy-auto-update-legacy-lock-"));
+  const lockPath = join(root, "state.json.lock");
+  await writeFile(lockPath, `${Date.now() - 60_000}\n`, "utf8");
+  const old = new Date(Date.now() - 60_000);
+  await utimes(lockPath, old, old);
+
+  const lock = await acquireLock(lockPath, Date.now(), 1);
+
+  assert.notEqual(lock, null);
+  await lock.release();
 });
 
 test("install flow detects marketplace, npx snapshot, workspace, and unknown snapshot states", async () => {

--- a/test/cli-evidence.test.js
+++ b/test/cli-evidence.test.js
@@ -180,7 +180,7 @@ test("CLI loop trace text shows evidence trail and missing proof", async () => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Superloopy trace/);
   assert.match(result.stdout, /Evidence summary: 1 artifact-backed criteria, 1 missing proof, 2 timeline events/);
-  assert.match(result.stdout, /Evidence artifacts:\n- G001\/C001 pass at \d{4}-\d{2}-\d{2}T.* `.superloopy\/evidence\/g001-c001.txt` - notes: manual smoke covered\n\nMissing proof:/);
+  assert.match(result.stdout, /Evidence artifacts:\n- G001\/C001 pass at \d{4}-\d{2}-\d{2}T.* `.superloopy\/evidence\/g001-c001.txt` - Happy path works from the real user-facing surface\. - notes: manual smoke covered\n\nMissing proof:/);
   assert.match(result.stdout, /Missing proof:/);
   assert.match(result.stdout, /G001\/C002 pending -> `.superloopy\/evidence\/G001-C002.txt`/);
   assert.match(result.stdout, /Timeline:/);

--- a/test/concurrency.test.js
+++ b/test/concurrency.test.js
@@ -66,6 +66,17 @@ test("withFileLock reclaims a stale lock instead of blocking forever", async () 
   assert.equal(ran, true);
 });
 
+test("withFileLock reclaims a stale corrupt lock token", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "superloopy-lock-"));
+  const target = join(dir, "corrupt.json");
+  await writeFile(`${target}.lock`, "not-a-valid-lock-token\n", "utf8");
+  let ran = false;
+  await withFileLock(target, async () => {
+    ran = true;
+  }, { staleMs: -1, timeoutMs: 1000 });
+  assert.equal(ran, true);
+});
+
 test("withFileLock fails closed when a fresh lock is held past the timeout", async () => {
   const dir = await mkdtemp(join(tmpdir(), "superloopy-lock-"));
   const target = join(dir, "z.json");
@@ -76,4 +87,13 @@ test("withFileLock fails closed when a fresh lock is held past the timeout", asy
   );
   // A live holder's lock must never be reclaimed/deleted by a waiter.
   assert.ok(existsSync(`${target}.lock`));
+});
+
+test("withFileLock release does not delete a successor token", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "superloopy-lock-"));
+  const target = join(dir, "successor.json");
+  await withFileLock(target, async () => {
+    await writeFile(`${target}.lock`, "successor-token\n", "utf8");
+  });
+  assert.equal(await readFile(`${target}.lock`, "utf8"), "successor-token\n");
 });

--- a/test/doctor-packed.test.js
+++ b/test/doctor-packed.test.js
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
+import { isSourceCheckoutRoot } from "../src/source-checkout.js";
+
 // Regression coverage for issue #14: `npm pack` always strips these repo-only files
 // from the tarball, so a packed install legitimately lacks them while the file audit
 // doc still lists their inventory rows. Doctor must not report the install as broken.
@@ -110,4 +112,17 @@ test("doctor still flags stale packaging rows in a tracked monorepo subdirectory
   const parsed = JSON.parse(result.stdout);
   assert.equal(parsed.checks.fileAudit.ok, false);
   assert.ok(parsed.checks.fileAudit.staleRows.includes(".gitignore"), JSON.stringify(parsed.checks.fileAudit.staleRows));
+});
+
+test("source checkout detection falls back safely when git is unavailable", async () => {
+  const repo = await mkdtemp(join(tmpdir(), "superloopy-source-checkout-"));
+  const oldPath = process.env.PATH;
+  process.env.PATH = "";
+  try {
+    assert.equal(isSourceCheckoutRoot(repo), false);
+    await mkdir(join(repo, ".git"));
+    assert.equal(isSourceCheckoutRoot(repo), true);
+  } finally {
+    process.env.PATH = oldPath;
+  }
 });

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
-import { normalizeComparisonPath } from "../src/comparison-similarity.js";
+import { checkComparisonSimilarity, normalizeComparisonPath } from "../src/comparison-similarity.js";
 import { formatDoctor, runDoctor } from "../src/doctor.js";
 import { checkWrapper, evaluateWrapperCurrency } from "../src/wrapper-check.js";
 import { parseBinShimCliPath } from "../src/agents.js";
@@ -22,8 +22,8 @@ function runCli(args, options = {}) {
   });
 }
 
-async function tempRepoCopy() {
-  const repo = await mkdtemp(join(tmpdir(), "superloopy-doctor-"));
+async function tempRepoCopy({ initGit = true, prefix = "superloopy-doctor-" } = {}) {
+  const repo = await mkdtemp(join(tmpdir(), prefix));
   const result = spawnSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], {
     cwd: process.cwd(),
     encoding: "utf8"
@@ -36,24 +36,7 @@ async function tempRepoCopy() {
     await mkdir(dirname(target), { recursive: true });
     await writeFile(target, await readFile(source));
   }
-  spawnSync("git", ["init"], { cwd: repo, encoding: "utf8" });
-  return repo;
-}
-
-async function tempInstalledCacheCopy() {
-  const repo = await mkdtemp(join(tmpdir(), "superloopy-cache-"));
-  const result = spawnSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], {
-    cwd: process.cwd(),
-    encoding: "utf8"
-  });
-  assert.equal(result.status, 0, result.stderr);
-  for (const file of result.stdout.split("\n").filter(Boolean)) {
-    const source = join(process.cwd(), file);
-    if (!existsSync(source)) continue;
-    const target = join(repo, file);
-    await mkdir(dirname(target), { recursive: true });
-    await writeFile(target, await readFile(source));
-  }
+  if (initGit) spawnSync("git", ["init"], { cwd: repo, encoding: "utf8" });
   return repo;
 }
 
@@ -341,7 +324,7 @@ test("doctor ignores Codex marketplace install metadata in plugin cache", async 
 });
 
 test("doctor accepts installed plugin caches that are not Git repositories", async () => {
-  const repo = await tempInstalledCacheCopy();
+  const repo = await tempRepoCopy({ initGit: false, prefix: "superloopy-cache-" });
 
   const result = await runDoctor(repo);
 
@@ -421,6 +404,26 @@ test("doctor comparison scan fails on copied-looking blocks", async () => {
 
 test("comparison scan normalizes Windows reference paths in findings", () => {
   assert.equal(normalizeComparisonPath("src\\external-loop.js"), "src/external-loop.js");
+});
+
+test("comparison scan reports missing git binary without a TypeError", async () => {
+  const repo = await tempComparisonTree({});
+  const comparison = await tempComparisonTree({});
+  const oldPath = process.env.PATH;
+  process.env.PATH = "";
+  try {
+    const result = await checkComparisonSimilarity(repo, {
+      sources: [{ key: "external", name: "External comparison", audited: "0".repeat(40) }],
+      comparisonPaths: { external: comparison },
+      listFiles: () => []
+    });
+
+    assert.equal(result.ok, false);
+    assert.doesNotMatch(result.message, /Cannot read properties/);
+    assert.match(result.message, /git|HEAD|spawn/i);
+  } finally {
+    process.env.PATH = oldPath;
+  }
 });
 
 test("doctor file audit fails when an inventory row loses boundary evidence", async () => {

--- a/test/golden-audit.test.js
+++ b/test/golden-audit.test.js
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { auditLoop } from "../src/audit.js";
-import { resolveEvidenceOutputPath, validateQualityGate } from "../src/artifacts.js";
+import { resolveEvidenceOutputPath, validateQualityGate, writeEvidenceOutputFile } from "../src/artifacts.js";
 import { captureLoop } from "../src/capture.js";
 import { createLoop, evidenceLoop, nextLoop } from "../src/loop.js";
 import { isTrustedCommand, recordTrustedCommand, trustLoop } from "../src/plan-trust.js";
@@ -185,6 +185,28 @@ test("SECURITY: evidence output path rejects a symlink escaping the evidence roo
     /symlink|resolve under/i
   );
   assert.equal(await readFile(outsideTarget, "utf8"), "original\n", "target outside evidence must be untouched");
+});
+
+test("SECURITY: evidence output write rejects a symlink swapped in after path resolution", async () => {
+  const { symlink, mkdir: mkdirp } = await import("node:fs/promises");
+  const repo = await tempRepo();
+  await createLoop(repo, ["--brief", "Ship"]);
+  const evidenceRoot = join(repo, ".superloopy", "evidence");
+  await mkdirp(evidenceRoot, { recursive: true });
+  const output = resolveEvidenceOutputPath(repo, ".superloopy/evidence/race.txt", undefined);
+  const outsideTarget = join(repo, "outside-race.txt");
+  await writeFile(outsideTarget, "original\n", "utf8");
+  try {
+    await symlink(outsideTarget, output.absolutePath);
+  } catch {
+    return;
+  }
+
+  await assert.rejects(
+    writeEvidenceOutputFile(output, "replacement\n"),
+    /symlink|ELOOP|not follow/i
+  );
+  assert.equal(await readFile(outsideTarget, "utf8"), "original\n");
 });
 
 test("SECURITY: evidence output path rejects a symlinked evidence root", async () => {

--- a/test/golden-review-gate.test.js
+++ b/test/golden-review-gate.test.js
@@ -3,6 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 
+import { enforceAuditProvenance } from "../src/audit-gate-verify.js";
 import { createLoop } from "../src/loop.js";
 import { reviewStyleQualityGate, runCli, tempRepo, writeEvidence, writeGenuineAuditVerdict, writeQualityGateArtifacts } from "./golden-helpers.js";
 
@@ -66,6 +67,48 @@ test("golden: completion rejects a hand-written audit verdict not bound to a re-
   assert.match(result.stderr, /verdict|audit/i);
   const plan = JSON.parse(await readFile(join(repo, ".superloopy", "goals.json"), "utf8"));
   assert.equal(plan.aggregateCompletion, null); // never force-completed
+});
+
+test("audit provenance direct: rejects hand-written verdict artifacts", async () => {
+  const repo = await tempRepo();
+  await createLoop(repo, ["--brief", "Ship"]);
+  const c1 = await writeEvidence(repo, "c1.txt");
+  const c2 = await writeEvidence(repo, "c2.txt");
+  runCli(["loop", "evidence", "--goal-id", "G001", "--criterion-id", "C001", "--status", "pass", "--artifact", c1], { cwd: repo });
+  runCli(["loop", "evidence", "--goal-id", "G001", "--criterion-id", "C002", "--status", "pass", "--artifact", c2], { cwd: repo });
+  const gate = reviewStyleQualityGate(await writeQualityGateArtifacts(repo));
+
+  await assert.rejects(
+    enforceAuditProvenance(repo, undefined, gate.audit),
+    /Audit verdict|verdict|audit/i
+  );
+});
+
+test("audit provenance direct: rejects any passed command criterion whose floor no longer reproduces", async () => {
+  const repo = await tempRepo();
+  await createLoop(repo, ["--brief", "Ship"]);
+  const c1 = await writeEvidence(repo, "c1.txt");
+  const c2 = await writeEvidence(repo, "c2.txt");
+  runCli([
+    "loop",
+    "evidence",
+    "--goal-id",
+    "G001",
+    "--criterion-id",
+    "C001",
+    "--status",
+    "pass",
+    "--artifact",
+    c1,
+    "--command",
+    "[\"node\",\"-e\",\"process.exit(1)\"]"
+  ], { cwd: repo });
+  runCli(["loop", "evidence", "--goal-id", "G001", "--criterion-id", "C002", "--status", "pass", "--artifact", c2], { cwd: repo });
+
+  await assert.rejects(
+    enforceAuditProvenance(repo, undefined, undefined),
+    /G001\/C001|passing floor/
+  );
 });
 
 test("golden: completion re-derives EVERY passed criterion, not just cited ones (uncited failing command criterion is caught)", async () => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -425,7 +425,7 @@ test("hook context includes recorded evidence for already-passed criteria", asyn
 
   const context = JSON.parse(output).hookSpecificOutput.additionalContext;
   assert.match(context, /Recorded evidence:/);
-  assert.match(context, /G001\/C001 pass at \d{4}-\d{2}-\d{2}T.* -> `.superloopy\/evidence\/c1.txt` - notes: manual smoke covered/);
+  assert.match(context, /G001\/C001 pass at \d{4}-\d{2}-\d{2}T.* -> `.superloopy\/evidence\/c1.txt` - Happy path works from the real user-facing surface\. - notes: manual smoke covered/);
 });
 
 test("runStopHook stays silent when Superloopy aggregate is complete", async () => withStopHookEnabled(async () => {

--- a/test/humanize-korean.test.js
+++ b/test/humanize-korean.test.js
@@ -44,6 +44,26 @@ test("humanize audit rejects non-Korean source text", async () => {
   assert.match(result.stderr, /Korean source text required/);
 });
 
+test("humanize audit writes a report when input files cannot be read", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "superloopy-humanize-missing-"));
+  const reportPath = join(dir, "audit.json");
+  const result = spawnSync(process.execPath, [
+    script,
+    "--source",
+    join(dir, "missing-source.md"),
+    "--final",
+    join(dir, "missing-final.md"),
+    "--report",
+    reportPath
+  ], { encoding: "utf8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unable to read source file/);
+  const report = JSON.parse(await readFile(reportPath, "utf8"));
+  assert.equal(report.ok, false);
+  assert.match(report.problems[0], /Unable to read source file/);
+});
+
 test("humanize audit rejects missing protected tokens", async () => {
   const files = await writeCase(
     "Transferloom 1.4.0은 2026년 7월 1일에 배포됐다.",

--- a/test/loop-gates.test.js
+++ b/test/loop-gates.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import "./helpers/trust-isolate.js";
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -12,6 +13,7 @@ import { reportLoop } from "../src/report.js";
 import { traceLoop } from "../src/trace.js";
 import { checkpointLoop, createLoop, evidenceLoop, reviewLoop, statusLoop } from "../src/loop.js";
 import { recordTrustedCommand } from "../src/plan-trust.js";
+import { goalsPath } from "../src/store.js";
 
 
 async function tempRepo() {
@@ -332,6 +334,32 @@ test("checkpointLoop serializes final plan mutation with concurrent evidence wri
   const persisted = await statusLoop(repo);
   assert.equal(persisted.plan.goals[0].criteria[1].notes, "recorded during final checkpoint");
   assert.equal(persisted.plan.aggregateCompletion.status, "complete");
+});
+
+test("checkpointLoop re-derives audit provenance before acquiring the goals lock", async () => {
+  const repo = await tempRepo();
+  await createLoop(repo, ["--brief", "Ship a CLI loop"]);
+  const slowCommand = [process.execPath, "-e", "setTimeout(() => process.exit(0), 250)"];
+  const c1 = await writeEvidence(repo, "c1.txt");
+  const c2 = await writeEvidence(repo, "c2.txt");
+  await evidenceLoop(repo, ["--goal-id", "G001", "--criterion-id", "C001", "--status", "pass", "--artifact", c1, "--command", JSON.stringify(slowCommand)]);
+  await evidenceLoop(repo, ["--goal-id", "G001", "--criterion-id", "C002", "--status", "pass", "--artifact", c2]);
+  await recordTrustedCommand(repo, slowCommand);
+  await writeFile(join(repo, ".superloopy", "evidence", "gate.json"), JSON.stringify({ status: "passed", artifacts: [c1, c2] }), "utf8");
+
+  const checkpoint = checkpointLoop(repo, [
+    "--goal-id",
+    "G001",
+    "--status",
+    "complete",
+    "--evidence",
+    "done",
+    "--quality-gate",
+    ".superloopy/evidence/gate.json"
+  ]);
+  await sleep(50);
+  assert.equal(existsSync(`${goalsPath(repo)}.lock`), false, "checkpoint must not hold goals lock while re-deriving audit provenance");
+  await checkpoint;
 });
 
 test("default gate re-derives the floor and blocks completion when a command no longer reproduces (P0.1)", async () => {

--- a/test/loop-gates.test.js
+++ b/test/loop-gates.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import "./helpers/trust-isolate.js";
+import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, readFile, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,6 +24,27 @@ async function writeEvidence(repo, name, content = "proof\n") {
   const path = join(evidenceDir, name);
   await writeFile(path, content, "utf8");
   return `.superloopy/evidence/${name}`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function runCliAsync(args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [join(process.cwd(), "src/cli.js"), ...args], {
+      cwd: options.cwd ?? process.cwd(),
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("exit", (status) => resolve({ status, stdout, stderr }));
+  });
 }
 
 test("traceLoop summarizes evidence artifacts, missing criteria, and ledger timeline", async () => {
@@ -265,6 +287,51 @@ test("checkpointLoop completes aggregate with artifact-backed quality gate", asy
   assert.equal(result.guide.nextAction.command, "superloopy loop status --json");
   assert.equal(persisted.summary.aggregateComplete, true);
   assert.match(ledger, /aggregate_completed/);
+});
+
+test("checkpointLoop serializes final plan mutation with concurrent evidence writes", async () => {
+  const repo = await tempRepo();
+  await createLoop(repo, ["--brief", "Ship a CLI loop"]);
+  const slowCommand = [process.execPath, "-e", "setTimeout(() => process.exit(0), 250)"];
+  const c1 = await writeEvidence(repo, "c1.txt");
+  const c2 = await writeEvidence(repo, "c2.txt");
+  await evidenceLoop(repo, ["--goal-id", "G001", "--criterion-id", "C001", "--status", "pass", "--artifact", c1, "--command", JSON.stringify(slowCommand)]);
+  await evidenceLoop(repo, ["--goal-id", "G001", "--criterion-id", "C002", "--status", "pass", "--artifact", c2]);
+  await recordTrustedCommand(repo, slowCommand);
+  await writeFile(join(repo, ".superloopy", "evidence", "gate.json"), JSON.stringify({ status: "passed", artifacts: [c1, c2] }), "utf8");
+
+  const checkpoint = checkpointLoop(repo, [
+    "--goal-id",
+    "G001",
+    "--status",
+    "complete",
+    "--evidence",
+    "done",
+    "--quality-gate",
+    ".superloopy/evidence/gate.json"
+  ]);
+  await sleep(50);
+  const evidence = runCliAsync([
+    "loop",
+    "evidence",
+    "--goal-id",
+    "G001",
+    "--criterion-id",
+    "C002",
+    "--status",
+    "pass",
+    "--artifact",
+    c2,
+    "--notes",
+    "recorded during final checkpoint"
+  ], { cwd: repo });
+  await checkpoint;
+  const evidenceResult = await evidence;
+  assert.equal(evidenceResult.status, 0, evidenceResult.stderr);
+
+  const persisted = await statusLoop(repo);
+  assert.equal(persisted.plan.goals[0].criteria[1].notes, "recorded during final checkpoint");
+  assert.equal(persisted.plan.aggregateCompletion.status, "complete");
 });
 
 test("default gate re-derives the floor and blocks completion when a command no longer reproduces (P0.1)", async () => {

--- a/test/loop.test.js
+++ b/test/loop.test.js
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { beginLoop } from "../src/begin.js";
-import { captureLoop } from "../src/capture.js";
+import { captureLoop, runCaptured } from "../src/capture.js";
 import { proveLoop } from "../src/prove.js";
 import {
 
@@ -42,6 +42,14 @@ test("createLoop creates light-mode goals with two strict evidence criteria", as
   assert.equal(result.summary.criteria.pending, 2);
   assert.equal(result.guide.state, "start_goal");
   assert.equal(result.guide.nextAction.command, "superloopy loop next --json");
+});
+
+test("createLoop accepts a brief value that starts with --", async () => {
+  const repo = await tempRepo();
+
+  const result = await createLoop(repo, ["--brief", "--fix the parser"]);
+
+  assert.equal(result.plan.goals[0].objective, "--fix the parser");
 });
 
 test("beginLoop creates a plan and starts the first goal in one command", async () => {
@@ -84,6 +92,14 @@ test("statusLoop returns the immediate guide", async () => {
   assert.equal(result.summary.goals.pending, 1);
   assert.equal(result.guide.state, "start_goal");
   assert.equal(result.guide.nextAction.command, "superloopy loop next --json");
+});
+
+test("statusLoop rejects malformed plan shape with a clear error", async () => {
+  const repo = await tempRepo();
+  await mkdir(join(repo, ".superloopy"), { recursive: true });
+  await writeFile(join(repo, ".superloopy", "goals.json"), "{\"version\":1}\n", "utf8");
+
+  await assert.rejects(statusLoop(repo), /Invalid Superloopy plan: goals must be an array/);
 });
 
 test("guideLoop points an idle plan at the exact next command", async () => {
@@ -284,6 +300,25 @@ test("captureLoop records pass evidence with a command transcript", async () => 
   assert.equal(result.guide.criterion.id, "C002");
   assert.match(transcript, /exitCode: 0/);
   assert.match(transcript, /\[stdout\]\ncaptured ok\n/);
+});
+
+test("runCaptured does not fail a successful command because stdout exceeds 10MB", async () => {
+  const repo = await tempRepo();
+  const artifact = {
+    absolutePath: join(repo, ".superloopy", "evidence", "large-output.txt"),
+    relativePath: ".superloopy/evidence/large-output.txt"
+  };
+
+  const capture = await runCaptured(repo, [
+    process.execPath,
+    "-e",
+    "process.stdout.write('x'.repeat(11 * 1024 * 1024))"
+  ], artifact);
+  const transcript = await readFile(artifact.absolutePath, "utf8");
+
+  assert.equal(capture.status, "pass");
+  assert.equal(capture.exitCode, 0);
+  assert.match(transcript, /stdout truncated after \d+ bytes/);
 });
 
 test("captureLoop records fail evidence when the command exits nonzero", async () => {

--- a/test/visual-diff.test.js
+++ b/test/visual-diff.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { Buffer } from "node:buffer";
 import test from "node:test";
 
 import { decodePng, diffImages, encodePng } from "../skills/superloopy-frontend/scripts/visual-diff.mjs";
@@ -15,6 +16,23 @@ function decoded(width, height, rgba) {
   return decodePng(encodePng(width, height, rgba));
 }
 
+function pngWithDimensions(width, height) {
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  const chunk = (type, data) => {
+    const out = Buffer.alloc(12 + data.length);
+    out.writeUInt32BE(data.length, 0);
+    out.write(type, 4, "ascii");
+    data.copy(out, 8);
+    return out;
+  };
+  return Buffer.concat([signature, chunk("IHDR", ihdr), chunk("IEND", Buffer.alloc(0))]);
+}
+
 test("encode/decode round-trips RGBA pixels through all PNG filters", () => {
   const rgba = solid(16, 16, [255, 255, 255, 255]);
   rgba[0] = 10; rgba[1] = 20; rgba[2] = 30; rgba[3] = 200; // one off pixel
@@ -22,6 +40,13 @@ test("encode/decode round-trips RGBA pixels through all PNG filters", () => {
   assert.equal(back.width, 16);
   assert.equal(back.height, 16);
   assert.deepEqual(Array.from(back.rgba.slice(0, 4)), [10, 20, 30, 200]);
+});
+
+test("decodePng rejects oversized IHDR dimensions before inflating pixel data", () => {
+  assert.throws(
+    () => decodePng(pngWithDimensions(40_000, 40_000)),
+    /PNG dimensions exceed/
+  );
 });
 
 test("identical images score 100 with no hotspots", () => {


### PR DESCRIPTION
## Summary
- Fix Superloopy plan/state races by locking final checkpoint and steering mutations through read-modify-write.
- Harden evidence artifacts, capture streaming, auto-update state/locks, PNG decode limits, Korean humanize failure reports, and Windows command shim routing.
- Consolidate repeated render/command/gate helpers and bump release metadata to 0.7.3.
- Preserve legacy timestamp-only auto-update lock reclaim while adding PID-token live-holder protection.

## Validation
- `node --test test/auto-update.test.js`
- `node --check src/auto-update-state.js`
- `npm test` (375/375)
- `git diff --check`
