### PR TITLE
doctor: ignore host .in_use heartbeat files in file audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "superloopy",
       "source": "./",
       "description": "Strict evidence loop harness: repo-local loop state, success criteria, append-only ledgers, evidence-gated completion, plus skills (loop, research, frontend, clone) and a read-only/worker crew. Works on Claude Code and Codex from one repo.",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Lightweight loop harness with strict evidence gates — Claude Code edition.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Lightweight loop harness with strict evidence gates.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superloopy",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superloopy",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "bin": {
         "superloopy": "src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A lightweight loop harness for Codex and Claude Code with strict evidence gates.",
   "type": "module",
   "bin": {

--- a/src/doctor.js
+++ b/src/doctor.js
@@ -302,7 +302,10 @@ function walkVisibleFiles(cwd, prefix, files) {
   }
 }
 
-const SKIP_FILESYSTEM_DIRS = new Set([".git", ".superloopy", "coverage", "dist", "node_modules", "vendor"]);
+// `.in_use` holds host-written `<pid>` heartbeat files that mark a cached plugin
+// version as active so it is not garbage-collected; they are runtime state, not
+// shipped files, so the audit walk must never see them.
+const SKIP_FILESYSTEM_DIRS = new Set([".git", ".in_use", ".superloopy", "coverage", "dist", "node_modules", "vendor"]);
 
 function isNotGitRepository(result) {
   // The `git` binary itself is missing (spawn failed: error set / status null / no stderr) OR the cwd
@@ -315,6 +318,7 @@ function isNotGitRepository(result) {
 function isRuntimeFile(file) {
   return file === ".DS_Store"
     || file.endsWith("/.DS_Store")
+    || file.startsWith(".in_use/")
     || file.startsWith(".superloopy/")
     || file.startsWith("node_modules/")
     || file.startsWith("coverage/")

--- a/test/doctor-packed.test.js
+++ b/test/doctor-packed.test.js
@@ -114,6 +114,29 @@ test("doctor still flags stale packaging rows in a tracked monorepo subdirectory
   assert.ok(parsed.checks.fileAudit.staleRows.includes(".gitignore"), JSON.stringify(parsed.checks.fileAudit.staleRows));
 });
 
+// Claude Code marks an actively used cached plugin version by writing `.in_use/<pid>`
+// heartbeat files into the install root so it is not garbage-collected mid-session.
+// They are host runtime state, not shipped files: the file audit must ignore them
+// instead of reporting the install as broken.
+test("doctor ignores host .in_use heartbeat files in a packed install", async () => {
+  const packed = await tempNpmPackedCopy();
+  await mkdir(join(packed, ".in_use"), { recursive: true });
+  await writeFile(join(packed, ".in_use", "12345"), '{"pid":12345,"procStart":"Fri Jul 10 07:00:03 2026"}', "utf8");
+  await writeFile(join(packed, ".in_use", "67890"), '{"pid":67890,"procStart":"Fri Jul 10 06:52:23 2026"}', "utf8");
+
+  const result = spawnSync(process.execPath, [join(packed, "src", "cli.js"), "doctor", "--json"], {
+    cwd: packed,
+    encoding: "utf8",
+    timeout: 30_000
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.checks.fileAudit.ok, true);
+  assert.deepEqual(parsed.checks.fileAudit.missing, []);
+});
+
 test("source checkout detection falls back safely when git is unavailable", async () => {
   const repo = await mkdtemp(join(tmpdir(), "superloopy-source-checkout-"));
   const oldPath = process.env.PATH;


### PR DESCRIPTION
## Problem

`superloopy doctor` reports `ok: false` on every Claude Code marketplace install that has (or had) an active session:

```
fileAudit: File audit missing entries: .in_use/16880, .in_use/93757.
```

Claude Code writes `.in_use/<pid>` heartbeat files (`{"pid":…,"procStart":…}`) into the installed plugin cache root to mark that version as actively used so it is not garbage-collected mid-session. These are host runtime state, not shipped files.

## Root cause

The cache root has no `.git`, so `listGitVisibleFiles` falls back to the raw filesystem walk (`listFilesystemVisibleFiles`). `SKIP_FILESYSTEM_DIRS` did not include `.in_use`, so the heartbeat files were swept into the audited file set; they are absent from `docs/superloopy-file-audit.md`, so `checkFileAudit` fails and `runDoctor`'s all-checks-must-pass aggregate flips the whole report to `ok: false`.

This is the `.in_use` sibling of the packed-install fileAudit false positive tracked in #14.

## Fix

- Add `.in_use` to `SKIP_FILESYSTEM_DIRS` so the walk never descends into it.
- Treat `.in_use/` paths as runtime files in `isRuntimeFile`, matching how `.superloopy/` runtime state is already handled.

## Testing

- New regression test in `test/doctor-packed.test.js`: an npm-packed install seeded with `.in_use/<pid>` heartbeat files must pass doctor cleanly. Verified red without the fix, green with it.
- Full suite: 541/541 pass.
- End-to-end: ran the fixed CLI's `doctor --root` against the real installed cache at `~/.claude/plugins/cache/beefiker/superloopy/0.9.0` (live heartbeat present) → `ok: true`.