### PR TITLE
fix(frontend): require string externalization for multi-locale targets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "superloopy",
       "source": "./",
       "description": "Strict evidence loop harness: repo-local loop state, success criteria, append-only ledgers, evidence-gated completion, plus skills (loop, research, frontend, clone) and a read-only/worker crew. Works on Claude Code and Codex from one repo.",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Lightweight loop harness with strict evidence gates — Claude Code edition.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Lightweight loop harness with strict evidence gates.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superloopy",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superloopy",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "bin": {
         "superloopy": "src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A lightweight loop harness for Codex and Claude Code with strict evidence gates.",
   "type": "module",
   "bin": {

--- a/skills/superloopy-frontend/references/qt.md
+++ b/skills/superloopy-frontend/references/qt.md
@@ -63,6 +63,7 @@ For Qt-owned non-Web pixels, this checklist replaces the Web anti-slop, browser-
 - [ ] Newer APIs have guards, a fallback, and a testable boundary.
 - [ ] The existing design source remains authoritative; any `DESIGN.md` is either that established source or a synchronized scoped mapping, and app semantics do not freeze the system palette, platform font, native metrics, or accessibility preferences.
 - [ ] Every supported input path (pointer, keyboard, touch, pen, switch, or assistive action as applicable) reaches the same truthful semantic outcome.
+- [ ] User-visible strings pass through `tr()`/`qsTr()` with a translation setup when the target implies more than one locale; a mismatched shipped language records its locale decision.
 - [ ] CJK, RTL, emoji/font fallback, long translations, and enlarged text remain usable.
 - [ ] High-DPI geometry and assets are correct across each target-supported DPR and display transition; unsupported transitions are recorded as not applicable.
 - [ ] Motion preferences and target-native system chrome are preserved or an explicit replacement is fully verified.

--- a/skills/superloopy-frontend/references/ux.md
+++ b/skills/superloopy-frontend/references/ux.md
@@ -139,7 +139,7 @@ Use consequence-scaled error handling. Preserve input, identify the specific cor
 
 ## Internationalization and bidirectionality
 
-Internationalization begins during discovery. Avoid display-string concatenation; use locale-aware formatting, sorting, searching, pluralization, and input. Carry language and direction metadata, and define whether a product language override follows the system, persists locally, syncs, or is unavailable.
+Internationalization begins during discovery. When the brief, audience, or distribution intent implies more than one locale (public release, open-source distribution, app-store or marketplace delivery), every user-visible string ships through the platform's translation mechanism (`tr()`/`qsTr()`, resource bundles, message catalogs) from the first artifact; hardcoded single-locale copy in a distribution-targeted surface is a defect, not a follow-up. When copy ships in a language different from the brief's language, record the locale decision and its reason instead of defaulting silently. Avoid display-string concatenation; use locale-aware formatting, sorting, searching, pluralization, and input. Carry language and direction metadata, and define whether a product language override follows the system, persists locally, syncs, or is unavailable.
 
 Test representative long text, unbroken content, bidirectional content, and taller-script content without assuming one universal expansion percentage. Mirroring is selective: media controls, charts, maps, and user-authored direction may not mirror with surrounding navigation.
 

--- a/test/frontend-ux-contract.test.js
+++ b/test/frontend-ux-contract.test.js
@@ -535,3 +535,13 @@ test("new UX references and contract tests are inventoried as original Superloop
   assert.match(fileAudit, /references\/ux\.md.*Superloopy-native.*original prose/is);
   assert.match(golden, /test\/frontend-ux-contract\.test\.js.*node --test/is);
 });
+
+test("i18n contract requires string externalization for distribution-targeted surfaces", async () => {
+  const ux = await read(reference("ux"));
+  const qt = await read(reference("qt"));
+
+  assert.match(ux, /more than one locale.*every user-visible string ships through the platform's translation mechanism/is);
+  assert.match(ux, /hardcoded single-locale copy in a distribution-targeted surface is a defect, not a follow-up/iu);
+  assert.match(ux, /language different from the brief's language.*record the locale decision/is);
+  assert.match(qt, /strings pass through `tr\(\)`\/`qsTr\(\)` with a translation setup/iu);
+});


### PR DESCRIPTION
## Summary

- add a string-externalization obligation to the shared i18n contract (`references/ux.md`): when the brief, audience, or distribution intent implies more than one locale, every user-visible string ships through the platform translation mechanism from the first artifact, and hardcoded single-locale copy in a distribution-targeted surface is a defect
- require a recorded locale decision when shipped copy differs from the brief's language
- add the matching Qt checklist row (`references/qt.md`) and pin both in `test/frontend-ux-contract.test.js`
- bump Superloopy to 0.12.1 across the five manifests

## Why

An end-to-end verification build against issue #28 (EQ Preset Studio, Qt Quick, https://github.com/beefiker/qt-audio-eq) reproduced complaint 3 exactly: a Korean brief with stated open-source distribution intent produced an English-only UI with zero `qsTr()`, no translation setup, and a visual-QA report that noted the mismatched language without flagging it. The existing contract treats localization as layout survival (CJK/RTL/long translations must not clip) but never obligates externalizing strings, so the model satisfied the letter of the contract while re-committing the original issue.

## Validation

- `npm test` — 654/654 passed
- new contract assertions fail if the obligation language is removed from either reference