### PR TITLE
Fix slides skill YAML frontmatter parsing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "superloopy",
       "source": "./",
       "description": "Strict evidence loop harness: repo-local loop state, success criteria, append-only ledgers, evidence-gated completion, plus skills (loop, research, frontend, clone) and a read-only/worker crew. Works on Claude Code and Codex from one repo.",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "MIT",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Lightweight loop harness with strict evidence gates — Claude Code edition.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Lightweight loop harness with strict evidence gates.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superloopy",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superloopy",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "MIT",
       "bin": {
         "superloopy": "src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "A lightweight loop harness for Codex and Claude Code with strict evidence gates.",
   "type": "module",
   "bin": {

--- a/skills/superloopy-slides/SKILL.md
+++ b/skills/superloopy-slides/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superloopy-slides
-description: Create beautiful, animation-rich HTML slide decks from scratch or by converting PowerPoint files — zero-dependency single-file presentations with curated distinctive styles, gated by real-browser visual-QA evidence on the Superloopy evidence spine. Use when the user wants slides, a presentation, a deck, a pitch deck, a talk, a keynote, or to convert a PPT/PPTX to web. Triggers — slides, presentation, deck, pitch deck, keynote, talk, PPT, PPTX, "make me a deck", "loopy slides". Discovers the user's aesthetic through visual style previews rather than abstract choices; supports PDF export and Vercel/Cloudflare Pages deployment. Live example deck built with this skill: https://fileloom-slides.pages.dev. NOT for general web pages or landing pages — use superloopy-frontend for those.
+description: "Use when the user asks for slides, a presentation, deck, pitch deck, talk, keynote, PowerPoint/PPT/PPTX conversion, or says loopy slides; not for general web pages or landing pages."
 ---
 
 # Superloopy Slides

--- a/skills/superloopy-slides/SKILL.md
+++ b/skills/superloopy-slides/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: superloopy-slides
-description: "Use when the user asks for slides, a presentation, deck, pitch deck, talk, keynote, PowerPoint/PPT/PPTX conversion, or says loopy slides; not for general web pages or landing pages."
+description: >-
+  Use when the user asks to create, convert, style, animate, export, share, or
+  deploy HTML slide decks, presentations, pitch decks, talks, or keynotes;
+  including zero-dependency or single-file output, PowerPoint/PPT/PPTX input,
+  PDF export, browser delivery, visual style exploration, or "loopy slides".
+  Not for general web pages or landing pages.
 ---
 
 # Superloopy Slides

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -25,6 +25,13 @@ test("skill frontmatter parser accepts CRLF line endings", () => {
   assert.match(frontmatter, /^description: test$/m);
 });
 
+test("slides skill keeps its description in a YAML-safe scalar", async () => {
+  const { frontmatter } = await readSkill("superloopy-slides");
+  const description = frontmatter.split("\n").find((line) => line.startsWith("description: ")) ?? "";
+
+  assert.match(description, /^description: (?:(?:".*")|(?:'.*')|(?:[>|][-+]?))$/u);
+});
+
 test("plugin manifest exposes Superloopy skills and packaged opt-in hooks", async () => {
   const plugin = JSON.parse(await readFile(".codex-plugin/plugin.json", "utf8"));
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -25,11 +25,16 @@ test("skill frontmatter parser accepts CRLF line endings", () => {
   assert.match(frontmatter, /^description: test$/m);
 });
 
-test("slides skill keeps its description in a YAML-safe scalar", async () => {
+test("slides skill keeps core routing contexts in a YAML-safe description", async () => {
   const { frontmatter } = await readSkill("superloopy-slides");
   const description = frontmatter.split("\n").find((line) => line.startsWith("description: ")) ?? "";
 
   assert.match(description, /^description: (?:(?:".*")|(?:'.*')|(?:[>|][-+]?))$/u);
+  assert.match(frontmatter, /HTML (?:slides|slide decks)/iu);
+  assert.match(frontmatter, /PowerPoint\/PPT\/PPTX/u);
+  assert.match(frontmatter, /PDF (?:output|export)/iu);
+  assert.match(frontmatter, /deploy/iu);
+  assert.match(frontmatter, /not for general web pages or landing pages/iu);
 });
 
 test("plugin manifest exposes Superloopy skills and packaged opt-in hooks", async () => {


### PR DESCRIPTION
## Summary

- use a folded YAML scalar so the slides skill frontmatter parses reliably
- preserve concise discovery coverage for HTML decks, PowerPoint/PPT/PPTX input, PDF export, visual exploration, deployment, and the general-web exclusion
- strengthen the regression test to protect both YAML safety and core routing contexts
- bump and synchronize the plugin version to `0.14.3`

## Validation

- `node --test test/plugin.test.js test/sync-version.test.js` (28 passed)
- `node src/cli.js doctor --root . --scope source --json` (`ok: true`, skills check passed)
- Ruby YAML parsing of `SKILL.md` and `agents/openai.yaml`
- metadata discovery evaluation selected the skill for HTML/PPTX, PDF/deployment, and visual-style prompts while excluding a general landing page
- `git diff --check`