### PR TITLE
chore: bump version to 0.17.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "superloopy",
       "source": "./",
       "description": "Strict evidence loop harness: repo-local loop state, success criteria, append-only ledgers, evidence-gated completion, plus skills (loop, research, frontend, clone) and a read-only/worker crew. Works on Claude Code and Codex from one repo.",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "keywords": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Lightweight loop harness with strict evidence gates — Claude Code edition.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Lightweight loop harness with strict evidence gates.",
   "homepage": "https://github.com/beefiker/superloopy#readme",
   "repository": "https://github.com/beefiker/superloopy",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superloopy",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superloopy",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "bin": {
         "superloopy": "src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superloopy",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "A lightweight loop harness for Codex and Claude Code with strict evidence gates.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump package and plugin manifest versions from 0.17.1 to 0.17.2 via `npm run sync-version`.
- Releases the gpt-6-astra routing policy change from #52.

## Verification
- `npm test`: 1037 pass, 0 fail.
- All four version fields (package.json, .claude-plugin/plugin.json, .claude-plugin/marketplace.json, .codex-plugin/plugin.json) read 0.17.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
